### PR TITLE
adopt renamed types

### DIFF
--- a/.changeset/moody-sloths-stand.md
+++ b/.changeset/moody-sloths-stand.md
@@ -1,0 +1,5 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+adopt changes in atprotoTypes, and moving convenience methods such as utf8Data into GermConvenience

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0a375f41203e0bf95eeecdc096b2d26796513adcb0443faf4273f3580d074601",
+  "originHash" : "7b7ba27896ae3b588a62e044ca02c0ed02a48b05fbbb5c4131a81984f1f47f8c",
   "pins" : [
     {
       "identity" : "atprototypes",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/germ-network/AtprotoTypes.git",
       "state" : {
-        "branch" : "reorg/rename+mocks",
-        "revision" : "dca95b47d6fce173b78416ed4cbbb44e3d9ca3ed"
+        "revision" : "d501cf01a9efc7c10cc9af76d876fef1c53da149",
+        "version" : "0.4.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/germ-network/GermConvenience.git",
       "state" : {
-        "revision" : "11e006791276ceb8236fae210e4ee521f80a0a41",
-        "version" : "0.1.4"
+        "revision" : "e98a7fc5301e1b1562f18180eb05bcfcdbd7632d",
+        "version" : "0.1.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6ebb59c1d49adf46bb1c8e007f45b016407dc32853f3d3e62ae2597dc9f32769",
+  "originHash" : "6bed5f0bd074cf7b91fd122f35562e2ab3e02c74b3baef266427b907a68f1fe0",
   "pins" : [
     {
       "identity" : "atprototypes",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/germ-network/AtprotoTypes.git",
       "state" : {
-        "revision" : "46d9cc0972f6ed9ad4efb9b5ec8191d5fddf875a",
-        "version" : "0.0.2"
+        "branch" : "reorg/rename+mocks",
+        "revision" : "45110bdd84318e3df793e7566611e45a0a47a1a0"
       }
     },
     {
@@ -29,12 +29,39 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
         "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
         "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6bed5f0bd074cf7b91fd122f35562e2ab3e02c74b3baef266427b907a68f1fe0",
+  "originHash" : "0a375f41203e0bf95eeecdc096b2d26796513adcb0443faf4273f3580d074601",
   "pins" : [
     {
       "identity" : "atprototypes",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/germ-network/AtprotoTypes.git",
       "state" : {
         "branch" : "reorg/rename+mocks",
-        "revision" : "45110bdd84318e3df793e7566611e45a0a47a1a0"
+        "revision" : "dca95b47d6fce173b78416ed4cbbb44e3d9ca3ed"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/germ-network/GermConvenience.git",
       "state" : {
-        "branch" : "reorg/rename+mocks",
-        "revision" : "0ffbfa63a7819405e367382276c4a1014b0fa98c"
+        "revision" : "11e006791276ceb8236fae210e4ee521f80a0a41",
+        "version" : "0.1.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,11 @@ let package = Package(
 	dependencies: [
 		.package(
 			url: "https://github.com/germ-network/AtprotoTypes.git",
-//			from: "0.0.2"
-			branch: "reorg/rename+mocks"
+			from: "0.4.0"
 		),
 		.package(
 			url: "https://github.com/germ-network/GermConvenience.git",
-			from: "0.1.4"
+			from: "0.1.5"
 		),
 	],
 	targets: [
@@ -31,7 +30,7 @@ let package = Package(
 			dependencies: [
 				.product(name: "AtprotoTypes", package: "AtprotoTypes"),
 				.product(name: "AtprotoTypesMocks", package: "AtprotoTypes"),
-				"GermConvenience"
+				"GermConvenience",
 			]
 		),
 		.testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
 	dependencies: [
 		.package(
 			url: "https://github.com/germ-network/AtprotoTypes.git",
-			from: "0.0.2"
+//			from: "0.0.2"
+			branch: "reorg/rename+mocks"
 		),
 		.package(
 			url: "https://github.com/germ-network/GermConvenience.git",

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ let package = Package(
 		),
 		.package(
 			url: "https://github.com/germ-network/GermConvenience.git",
-			//			from: "0.1.1"
-			branch: "reorg/rename+mocks"
+			from: "0.1.4"
 		),
 	],
 	targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
 		.target(
 			name: "CommProtocol",
 			dependencies: [
-				"AtprotoTypes",
+				.product(name: "AtprotoTypes", package: "AtprotoTypes"),
+				.product(name: "AtprotoTypesMocks", package: "AtprotoTypes"),
 				"GermConvenience"
 			]
 		),

--- a/Sources/CommProtocol/Anchors/AtprotoDiD+AnchorTo.swift
+++ b/Sources/CommProtocol/Anchors/AtprotoDiD+AnchorTo.swift
@@ -22,7 +22,7 @@ extension Atproto.DID: AnchorTo {
 	}
 
 	public var stableEncoded: Data {
-		stringRepresentation.utf8Data
+		rawValue.utf8Data
 	}
 }
 

--- a/Sources/CommProtocol/CoreIdentity.swift
+++ b/Sources/CommProtocol/CoreIdentity.swift
@@ -121,12 +121,6 @@ extension UInt8: LinearEncodable {
 	}
 }
 
-extension String {
-	public var utf8Data: Data {
-		Data(utf8)
-	}
-}
-
 extension Data {
 	var utf8String: String? {
 		String(bytes: self, encoding: .utf8)

--- a/Tests/CommProtocolTests/Anchors/ATProtoDIDAPI.swift
+++ b/Tests/CommProtocolTests/Anchors/ATProtoDIDAPI.swift
@@ -13,7 +13,7 @@ struct ATProtoDIDAPITests {
 	@Test func testArchive() throws {
 		let mock = Atproto.DID.mock()
 
-		let restored = try Atproto.DID(string: mock.stringRepresentation)
+		let restored = try Atproto.DID(string: mock.rawValue)
 		#expect(mock == restored)
 
 		let attestation = DependentIdentity(anchorTo: restored)

--- a/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
@@ -6,6 +6,7 @@
 //
 
 import AtprotoTypes
+import AtprotoTypesMocks
 import CommProtocol
 import CryptoKit
 import Testing


### PR DESCRIPTION
this also now has accessible base64UrlEncoded through GermConvenience, which was previously implemented in a client of this library