### PR TITLE
Fix anchor-key rotation succession verification

### DIFF
--- a/.changeset/fix-anchor-succession-verify.md
+++ b/.changeset/fix-anchor-succession-verify.md
@@ -1,0 +1,10 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Fix anchor-key rotation continuity. `verify(successionFrom:)` verified succession
+proofs under the successor key instead of the predecessor key that signed them, so
+any Hello carrying a proof (i.e. from a rotated anchor) failed with
+`.authenticationError`. Also fix `PrivateActiveAnchor.handOff()` truncating proof
+history to a single hop, which dropped continuity back to the original key across
+repeated rotations.

--- a/Sources/CommProtocol/Anchors/AnchorKey.swift
+++ b/Sources/CommProtocol/Anchors/AnchorKey.swift
@@ -267,7 +267,9 @@ extension AnchorPublicKey {
 		attestation: DependentIdentity
 	) throws -> AnchorPublicKey {
 		let predecessor = try AnchorPublicKey(archive: successionFrom.predecessor)
-		let result = verifier(
+		//the proof is signed by the predecessor endorsing this (successor) key,
+		//so it must verify under the predecessor's key, not our own
+		let result = predecessor.verifier(
 			successionFrom.signature,
 			try AnchorSuccession.signatureBody(
 				attestation: attestation,

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -55,10 +55,13 @@ public struct PrivateActiveAnchor: Sendable {
 					)
 			)
 
+		//accumulate the new proof onto the existing chain so continuity back to
+		//the original key survives repeated rotations (verify(proofs:) walks the
+		//full history predecessor-first)
 		return .init(
 			privateKey: newAnchor,
 			attestation: attestation,
-			history: [
+			history: history + [
 				.init(
 					first: .init(
 						predecessor: publicKey.archive,

--- a/Tests/CommProtocolTests/Anchors/AnchorSuccessionTests.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorSuccessionTests.swift
@@ -1,0 +1,74 @@
+//
+//  AnchorSuccessionTests.swift
+//  CommProtocol
+//
+//  Regression coverage for anchor-key rotation continuity: after a rotation,
+//  a Hello issued by the new anchor key carries a succession proof that a
+//  recipient must be able to verify back to the predecessor key(s).
+//
+
+import AtprotoTypes
+import AtprotoTypesMocks
+import CommProtocol
+import CryptoKit
+import Testing
+
+struct AnchorSuccessionTests {
+	let did = Atproto.DID.mock()
+
+	private func hello(
+		from anchor: PrivateActiveAnchor
+	) throws -> AnchorHello {
+		try anchor.generateHello(
+			helloAgent: anchor.createHelloAgent(),
+			agentVersion: .mock(),
+			mlsKeyPackages: ["mock".utf8Data],
+			policy: .closed
+		)
+	}
+
+	// Single rotation: the Hello from the rotated anchor must verify, and the
+	// recovered succession chain must be exactly the predecessor key.
+	// This is the direct regression guard for the verify(successionFrom:) direction.
+	@Test func testHelloVerifiesAcrossOneRotation() throws {
+		let v0 = PrivateActiveAnchor.create(for: did)
+		let k0 = v0.publicKey
+
+		let v1 = try v0.handOff()
+		#expect(v1.publicKey != k0)
+
+		let verified = try v1.publicKey.verify(
+			hello: try hello(from: v1),
+			for: .init(anchorTo: did)
+		)
+		#expect(verified.succession == [k0])
+	}
+
+	// Two rotations: continuity must reach all the way back to the original key,
+	// in predecessor-first order. Exercises both the verify direction and that
+	// handOff() accumulates (rather than truncates) proof history.
+	@Test func testHelloVerifiesAcrossTwoRotations() throws {
+		let v0 = PrivateActiveAnchor.create(for: did)
+		let k0 = v0.publicKey
+		let v1 = try v0.handOff()
+		let k1 = v1.publicKey
+		let v2 = try v1.handOff()
+
+		let verified = try v2.publicKey.verify(
+			hello: try hello(from: v2),
+			for: .init(anchorTo: did)
+		)
+		#expect(verified.succession == [k0, k1])
+	}
+
+	// A freshly created anchor has no history; its Hello verifies with an empty
+	// succession chain. This is the path the app exercises today and must stay green.
+	@Test func testHelloWithoutRotationHasEmptySuccession() throws {
+		let v0 = PrivateActiveAnchor.create(for: did)
+		let verified = try v0.publicKey.verify(
+			hello: try hello(from: v0),
+			for: .init(anchorTo: did)
+		)
+		#expect(verified.succession.isEmpty)
+	}
+}


### PR DESCRIPTION
Succession-proof verification checked the proof under the successor key rather than the predecessor key that actually signed it (a regression from e025259, which dropped the `predecessor.` qualifier when the recursive `verify(successor:)` was refactored into the chain-walker), so any Hello carrying a proof — i.e. from an anchor that had rotated its key — failed with `.authenticationError`. `PrivateActiveAnchor.handOff()` separately truncated proof history to a single hop, dropping continuity to the original key across repeated rotations. This whole path was unexercised by tests and unused by the app, so it went unnoticed; the new AnchorSuccessionTests cover one- and two-rotation continuity plus the no-rotation case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)