### PR TITLE
Harden: mocks target, signature domain separation, parsing, replay guard

### DIFF
--- a/.changeset/harden-review-findings.md
+++ b/.changeset/harden-review-findings.md
@@ -1,0 +1,15 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Hardening from the security/functional review:
+
+- Move mock factories out of the production library into a new `CommProtocolMocks`
+  product; consumers import it explicitly.
+- Throw (rather than silently drop entries) when anchor archive/proof-history
+  decoding fails.
+- Parse fixed-width integers with `loadUnaligned` instead of the alignment-sensitive
+  `load(as:)`.
+- Add `IdentityMutableData.supersedes(_:)` / `validateSupersedes(_:)` (and a
+  `ProtocolError.staleUpdate` case) so callers can reject replayed or rolled-back
+  mutable data by counter.

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
 		// Products define the executables and libraries a package produces, making them visible to other packages.
 		.library(
 			name: "CommProtocol",
-			targets: ["CommProtocol"])
+			targets: ["CommProtocol"]),
+		.library(
+			name: "CommProtocolMocks",
+			targets: ["CommProtocolMocks"]),
 	],
 	dependencies: [
 		.package(
@@ -35,9 +38,13 @@ let package = Package(
 				"GermConvenience",
 			]
 		),
+		.target(
+			name: "CommProtocolMocks",
+			dependencies: ["CommProtocol"]
+		),
 		.testTarget(
 			name: "CommProtocolTests",
-			dependencies: ["CommProtocol"]
+			dependencies: ["CommProtocol", "CommProtocolMocks"]
 		),
 	]
 )

--- a/Sources/CommProtocol/Anchors/Agent/AnchorAgentSource.swift
+++ b/Sources/CommProtocol/Anchors/Agent/AnchorAgentSource.swift
@@ -68,8 +68,8 @@ extension PrivateAnchorAgent {
 					.init(
 						anchorKey: anchorKey.wireFormat,
 						attestation: try attestation.wireFormat,
-						proofHistory: proofHistory.compactMap {
-							try? $0.wireFormat
+						proofHistory: try proofHistory.map {
+							try $0.wireFormat
 						}
 					)
 				}
@@ -78,8 +78,8 @@ extension PrivateAnchorAgent {
 			init(archive: Archive) throws {
 				anchorKey = try .init(wireFormat: archive.anchorKey)
 				attestation = try .finalParse(archive.attestation)
-				proofHistory = archive.proofHistory
-					.compactMap { try? .finalParse($0) }
+				proofHistory = try archive.proofHistory
+					.map { try .finalParse($0) }
 			}
 		}
 	}

--- a/Sources/CommProtocol/Anchors/Exchange/AnchorHello.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/AnchorHello.swift
@@ -142,8 +142,8 @@ extension AnchorHello {
 
 			self.init(
 				agent: try .init(archive: archive.agent),
-				succession: archive.succession
-					.compactMap { try? .init(wireFormat: $0) },
+				succession: try archive.succession
+					.map { try .init(wireFormat: $0) },
 				policy: policy,
 				version: try .finalParse(archive.version),
 				mlsKeyPackages: archive.mlsKeyPackages,

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -332,7 +332,7 @@ extension PrivateActiveAnchor {
 			.init(
 				privateKey: privateKey.archive.wireFormat,
 				attestation: attestation.archive,
-				history: history.compactMap { try? $0.wireFormat }
+				history: try history.map { try $0.wireFormat }
 			)
 		}
 	}
@@ -343,7 +343,7 @@ extension PrivateActiveAnchor {
 		self.init(
 			privateKey: privateKey,
 			attestation: try .init(archive: archive.attestation),
-			history: archive.history.compactMap { try? .finalParse($0) }
+			history: try archive.history.map { try .finalParse($0) }
 		)
 	}
 }

--- a/Sources/CommProtocol/CoreIdentity.swift
+++ b/Sources/CommProtocol/CoreIdentity.swift
@@ -158,6 +158,27 @@ public struct IdentityMutableData: Sendable, Equatable {
 	}
 }
 
+extension IdentityMutableData {
+	//Precedence is defined by `counter`. The signature only proves the signer
+	//authored this update, not that it is newer than one already applied, so a
+	//replayed or rolled-back update verifies fine. Callers hold the prior state
+	//and MUST gate application on this check to reject stale mutable data.
+
+	///Whether this update should replace `previous` (strictly newer counter).
+	public func supersedes(_ previous: IdentityMutableData) -> Bool {
+		counter > previous.counter
+	}
+
+	///Throwing form of ``supersedes(_:)``. A `nil` predecessor (no prior state)
+	///is always accepted; an equal or lower counter throws `.staleUpdate`.
+	public func validateSupersedes(_ previous: IdentityMutableData?) throws {
+		guard let previous else { return }
+		guard supersedes(previous) else {
+			throw ProtocolError.staleUpdate
+		}
+	}
+}
+
 extension IdentityMutableData: LinearEncodedQuad {
 	public var first: UInt16 { counter }
 	public var second: [String] { pronouns }

--- a/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
@@ -127,34 +127,3 @@ extension AppWelcome {
 		)
 	}
 }
-
-extension AppWelcome {
-	static public func mock(
-		remoteAgentKey: AgentPublicKey,
-		keyPackageData: Data
-	) throws -> AppWelcome {
-		let (identityKey, signedIdentity) =
-			try Mocks
-			.mockIdentity()
-
-		let groupId = DataIdentifier(width: .bits256)
-
-		let (agentKey, introduction) =
-			try identityKey
-			.createNewDelegate(
-				signedIdentity: signedIdentity,
-				identityMutable: .mock(),
-				agentType: .welcome(
-					remoteAgentId: remoteAgentKey,
-					groupId: groupId
-				)
-			)
-
-		return try agentKey.createAppWelcome(
-			introduction: introduction,
-			agentData: .mock(),
-			groupId: groupId,
-			keyPackageData: keyPackageData
-		)
-	}
-}

--- a/Sources/CommProtocol/MessageFraming/DeclaredWidth.swift
+++ b/Sources/CommProtocol/MessageFraming/DeclaredWidth.swift
@@ -21,7 +21,7 @@ extension UInt16 {
 		let copy = Data(dataRepresentation)
 
 		let bigEndian = copy.withUnsafeBytes { rawBuffer in
-			rawBuffer.load(as: UInt16.self)
+			rawBuffer.loadUnaligned(as: UInt16.self)
 		}
 
 		self = .init(bigEndian: bigEndian)

--- a/Sources/CommProtocol/Objects/Integers.swift
+++ b/Sources/CommProtocol/Objects/Integers.swift
@@ -53,7 +53,7 @@ extension UInt32 {
 		}
 
 		let bigEndian = copy.withUnsafeBytes { rawBuffer in
-			rawBuffer.load(as: UInt32.self)
+			rawBuffer.loadUnaligned(as: UInt32.self)
 		}
 
 		self = .init(bigEndian: bigEndian)
@@ -89,7 +89,7 @@ extension UInt64 {
 		}
 
 		let bigEndian = copy.withUnsafeBytes { rawBuffer in
-			rawBuffer.load(as: UInt64.self)
+			rawBuffer.loadUnaligned(as: UInt64.self)
 		}
 
 		self = .init(bigEndian: bigEndian)

--- a/Sources/CommProtocol/ProtocolError.swift
+++ b/Sources/CommProtocol/ProtocolError.swift
@@ -21,6 +21,7 @@ public enum ProtocolError: Error {
 	case incorrectAnchorType
 	case incorrectAnchorState
 	case unsupported
+	case staleUpdate
 	case missingOptional(String)
 	case unexpected(String)
 }
@@ -44,6 +45,8 @@ extension ProtocolError: LocalizedError {
 		case .incorrectAnchorType: "Incorrect anchor type"
 		case .incorrectAnchorState: "Incorrect anchor state"
 		case .unsupported: "Unsupported operation"
+		case .staleUpdate:
+			"Mutable data counter did not advance (possible replay or rollback)"
 		case .missingOptional(let string): "Missing optional \(string)"
 		case .unexpected(let string): "Unexpected \(string)"
 		}

--- a/Sources/CommProtocolMocks/AppWelcome+Mock.swift
+++ b/Sources/CommProtocolMocks/AppWelcome+Mock.swift
@@ -1,0 +1,40 @@
+//
+//  AppWelcome+Mock.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 2/9/25.
+//
+
+import CommProtocol
+import Foundation
+
+extension AppWelcome {
+	static public func mock(
+		remoteAgentKey: AgentPublicKey,
+		keyPackageData: Data
+	) throws -> AppWelcome {
+		let (identityKey, signedIdentity) =
+			try Mocks
+			.mockIdentity()
+
+		let groupId = DataIdentifier(width: .bits256)
+
+		let (agentKey, introduction) =
+			try identityKey
+			.createNewDelegate(
+				signedIdentity: signedIdentity,
+				identityMutable: .mock(),
+				agentType: .welcome(
+					remoteAgentId: remoteAgentKey,
+					groupId: groupId
+				)
+			)
+
+		return try agentKey.createAppWelcome(
+			introduction: introduction,
+			agentData: .mock(),
+			groupId: groupId,
+			keyPackageData: keyPackageData
+		)
+	}
+}

--- a/Sources/CommProtocolMocks/MockIdentity.swift
+++ b/Sources/CommProtocolMocks/MockIdentity.swift
@@ -5,6 +5,7 @@
 //  Created by Anna Mistele on 10/8/24.
 //
 
+import CommProtocol
 import CryptoKit
 
 extension IdentityPrivateKey {

--- a/Sources/CommProtocolMocks/Mocks.swift
+++ b/Sources/CommProtocolMocks/Mocks.swift
@@ -5,6 +5,7 @@
 //  Created by Mark @ Germ on 7/30/24.
 //
 
+import CommProtocol
 import CryptoKit
 import Foundation
 

--- a/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
@@ -8,6 +8,7 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocol
+import CommProtocolMocks
 import CryptoKit
 import Testing
 

--- a/Tests/CommProtocolTests/CommProposalTests.swift
+++ b/Tests/CommProtocolTests/CommProposalTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark Xue on 7/29/24.
 //
 
+import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing

--- a/Tests/CommProtocolTests/CommProtocolTests.swift
+++ b/Tests/CommProtocolTests/CommProtocolTests.swift
@@ -6,6 +6,7 @@
 //
 
 import CommProtocol
+import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing

--- a/Tests/CommProtocolTests/EncodingTests.swift
+++ b/Tests/CommProtocolTests/EncodingTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark @ Germ on 7/31/24.
 //
 
+import CommProtocolMocks
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
@@ -3,6 +3,7 @@
 //  CommProtocol
 //
 
+import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloReplyTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloReplyTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark Xue on 8/2/24.
 //
 
+import CommProtocolMocks
 import CryptoKit
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark Xue on 7/26/24.
 //
 
+import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing

--- a/Tests/CommProtocolTests/IdentityExchange/AppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AppWelcomeTests.swift
@@ -6,6 +6,7 @@
 //
 
 import CommProtocol
+import CommProtocolMocks
 import CryptoKit
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityKeyTests.swift
+++ b/Tests/CommProtocolTests/IdentityKeyTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark @ Germ on 6/15/24.
 //
 
+import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing

--- a/Tests/CommProtocolTests/IdentityMutableDataTests.swift
+++ b/Tests/CommProtocolTests/IdentityMutableDataTests.swift
@@ -1,0 +1,36 @@
+//
+//  IdentityMutableDataTests.swift
+//  CommProtocol
+//
+//  Covers counter-based precedence used to reject replayed/rolled-back updates.
+//
+
+import Testing
+
+@testable import CommProtocol
+
+struct IdentityMutableDataTests {
+	private func mutable(counter: UInt16) -> IdentityMutableData {
+		.init(counter: counter, pronouns: [], aboutText: nil, imageResource: nil)
+	}
+
+	@Test func testSupersedes() {
+		#expect(mutable(counter: 2).supersedes(mutable(counter: 1)))
+		#expect(!mutable(counter: 1).supersedes(mutable(counter: 2)))
+		#expect(!mutable(counter: 1).supersedes(mutable(counter: 1)))
+	}
+
+	@Test func testValidateSupersedesAcceptsNewerAndNoPrior() throws {
+		try mutable(counter: 5).validateSupersedes(mutable(counter: 4))
+		try mutable(counter: 5).validateSupersedes(nil)
+	}
+
+	@Test func testValidateSupersedesRejectsStaleAndEqual() {
+		#expect(throws: ProtocolError.staleUpdate) {
+			try mutable(counter: 3).validateSupersedes(mutable(counter: 4))
+		}
+		#expect(throws: ProtocolError.staleUpdate) {
+			try mutable(counter: 4).validateSupersedes(mutable(counter: 4))
+		}
+	}
+}

--- a/Tests/CommProtocolTests/SemanticVersionTests.swift
+++ b/Tests/CommProtocolTests/SemanticVersionTests.swift
@@ -5,6 +5,7 @@
 //  Created by Mark @ Germ on 6/24/24.
 //
 
+import CommProtocolMocks
 import Foundation
 import Testing
 


### PR DESCRIPTION
Resolves the remaining Low/Informational findings from the review, one commit each so they can be reviewed or reverted independently:

1. **CommProtocolMocks target** — moves the throwaway-key mock factories out of the production `CommProtocol` library into a new product; tests opt in via `import CommProtocolMocks`. Adopter note: external test code that imported these mocks from `CommProtocol` must now add `import CommProtocolMocks`.
2. **Fail-loud archive decode** — replaces `compactMap { try? }` with throwing `map` so a malformed proof/key surfaces instead of silently shortening a succession chain.
3. **loadUnaligned** — fixed-width integer parsing no longer relies on the alignment-sensitive `load(as:)`.
4. **Replay/rollback guard** — `IdentityMutableData.supersedes(_:)` / `validateSupersedes(_:)` (+ `ProtocolError.staleUpdate`) give callers an explicit counter-based gate; the library can't enforce it automatically since it doesn't hold prior state.

AgentHandoff domain separation, previously listed here, has been split out of this PR and is tracked separately on `feat/handoff-domain-separation-pq`.

Adds precedence tests; full suite green (46 tests). Independent of #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
