### PR TITLE
Version-gate AgentHandoff domain separation on agent version

### DIFF
--- a/.changeset/handoff-domain-separation-pq.md
+++ b/.changeset/handoff-domain-separation-pq.md
@@ -1,0 +1,11 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Domain-separate the `AgentHandoff` new-agent signing body, gated on
+`AgentUpdate.version`. Agents at/above `AgentUpdate.pqDomainSeparationVersion`
+prepend a discriminator; classical (sub-threshold) agents keep the pre-separation
+body byte-for-byte. Both signer and verifier derive the choice from the version
+inside the signed body, so it is deterministic and needs no separate rollout — it
+shadows the PQ capability version bump. Inert until an app declares a
+≥-threshold agent version.

--- a/.changeset/handoff-domain-separation-pq.md
+++ b/.changeset/handoff-domain-separation-pq.md
@@ -9,3 +9,8 @@ body byte-for-byte. Both signer and verifier derive the choice from the version
 inside the signed body, so it is deterministic and needs no separate rollout — it
 shadows the PQ capability version bump. Inert until an app declares a
 ≥-threshold agent version.
+
+Also add `AgentUpdate.pqCapableVersion` (2.3.0), the PQ parse-capability tier that
+sits below `pqDomainSeparationVersion`: an agent at this version advertises PQ
+capability while its handoff bodies stay undiscriminated, so the classical wire
+format is unchanged. It is `public` so the app imports the same constant.

--- a/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
+++ b/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
@@ -29,6 +29,32 @@ public struct AgentUpdate: Sendable, Equatable, Hashable {
 	}
 }
 
+extension AgentUpdate {
+	///The agent version at (and above) which handoff signing bodies become
+	///domain-separated (see `AgentHandoff.NewAgentTBS`).
+	///
+	///This shadows the post-quantum rollout: PQ capability is advertised by an
+	///agent version at or above a threshold (the field legacy peers already
+	///parse — see the app's `pq-card-in-session-negotiation.md`), so domain
+	///separation rides that same version bump rather than a flag day of its own.
+	///Classical (sub-threshold) agents keep the pre-separation body byte-for-byte.
+	///
+	///Placeholder above the current agent version so it is inert today; the value
+	///is the single coordination point and must match the app's PQ-capability
+	///threshold when PQ ships.
+	public static let pqDomainSeparationVersion = SemanticVersion(
+		major: 3,
+		minor: 0,
+		patch: 0
+	)
+
+	///Whether this agent's handoff signing body carries the domain-separation
+	///discriminator, per ``pqDomainSeparationVersion``.
+	var domainSeparatesHandoff: Bool {
+		version >= Self.pqDomainSeparationVersion
+	}
+}
+
 extension AgentUpdate: LinearEncodedTriple {
 	public var first: SemanticVersion { version }
 	public var second: Bool { isAppClip }

--- a/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
+++ b/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
@@ -30,6 +30,28 @@ public struct AgentUpdate: Sendable, Equatable, Hashable {
 }
 
 extension AgentUpdate {
+	///The agent version at (and above) which an agent advertises post-quantum
+	///*capability* — "I can speak PQ, come negotiate" — while its handoff signing
+	///bodies still parse WITHOUT the domain-separation discriminator.
+	///
+	///This is the "version >= T ⇒ PQ parse-capable" signal from the app's
+	///`pq-card-in-session-negotiation.md`, deliberately kept BELOW
+	///``pqDomainSeparationVersion`` so a capability-tier agent advertises PQ while
+	///its handoff bodies stay byte-for-byte legacy (see ``domainSeparatesHandoff``).
+	///`public` so the app imports the same constant as the single source of truth.
+	public static let pqCapableVersion = SemanticVersion(
+		major: 2,
+		minor: 3,
+		patch: 0
+	)
+
+	///Whether this agent advertises PQ capability, per ``pqCapableVersion``. This
+	///does not by itself domain-separate the handoff body — see
+	///``domainSeparatesHandoff``.
+	var isPQCapable: Bool {
+		version >= Self.pqCapableVersion
+	}
+
 	///The agent version at (and above) which handoff signing bodies become
 	///domain-separated (see `AgentHandoff.NewAgentTBS`).
 	///

--- a/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
+++ b/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
@@ -48,7 +48,7 @@ extension AgentUpdate {
 	///Whether this agent advertises PQ capability, per ``pqCapableVersion``. This
 	///does not by itself domain-separate the handoff body — see
 	///``domainSeparatesHandoff``.
-	var isPQCapable: Bool {
+	public var isPQCapable: Bool {
 		version >= Self.pqCapableVersion
 	}
 

--- a/Sources/CommProtocol/IdentityUpdate/AgentHandoff.swift
+++ b/Sources/CommProtocol/IdentityUpdate/AgentHandoff.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct AgentHandoff: Equatable, Sendable {
 	struct NewAgentTBS {
-		//		static let discriminator = Data("successorAgent".utf8)
+		static let discriminator = Data("successorAgent".utf8)
 		//All of these are injected and already known
 		let knownAgentKey: AgentPublicKey
 		let newAgentIdentity: IdentityPublicKey
@@ -19,14 +19,23 @@ public struct AgentHandoff: Equatable, Sendable {
 		//transmitted in this object
 		let agentData: AgentUpdate
 
+		//The discriminator is prepended only for agent versions at/above the PQ
+		//domain-separation threshold (AgentUpdate.pqDomainSeparationVersion).
+		//Classical agents omit it and stay byte-compatible with already-deployed
+		//verifiers. Signer and verifier both build this from the same agentData,
+		//and agentData.version is inside the signed body, so the choice is
+		//deterministic and tamper-evident.
 		var formatForSigning: Data {
 			get throws {
-				try knownAgentKey.wireFormat
+				let body =
+					try knownAgentKey.wireFormat
 					+ newAgentIdentity.id.wireFormat
 					+ context.wireFormat
 					+ updateMessage
 					+ agentData.wireFormat
-
+				return agentData.domainSeparatesHandoff
+					? Self.discriminator + body
+					: body
 			}
 		}
 	}

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
@@ -1,0 +1,116 @@
+//
+//  AgentHandoffDomainSeparationTests.swift
+//  CommProtocol
+//
+//  The AgentHandoff new-agent signing body is domain-separated only for agent
+//  versions at/above AgentUpdate.pqDomainSeparationVersion; classical agents keep
+//  the pre-separation body. Both branches must round-trip; classical must stay
+//  byte-identical to the plain concatenation.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+struct AgentHandoffDomainSeparationTests {
+	private struct Fixture {
+		let knownAgent: AgentPrivateKey
+		let newAgent: AgentPrivateKey
+		let newIdentity: IdentityPublicKey
+		let context: TypedDigest
+		let updateMessage: Data
+		let agentData: AgentUpdate
+		let tbs: AgentHandoff.NewAgentTBS
+
+		// Body with no discriminator — the pre-separation (classical) layout.
+		var plainBody: Data {
+			get throws {
+				try knownAgent.publicKey.wireFormat
+					+ newIdentity.id.wireFormat
+					+ context.wireFormat
+					+ updateMessage
+					+ agentData.wireFormat
+			}
+		}
+
+		func signedHandoff() throws -> AgentHandoff {
+			try AgentHandoff(
+				first: agentData,
+				second: newAgent.signer(tbs.formatForSigning)
+			)
+		}
+
+		func validate(_ handoff: AgentHandoff) throws -> AgentUpdate {
+			try handoff.validate(
+				knownAgent: knownAgent.publicKey,
+				newAgent: newAgent.publicKey,
+				newAgentIdentity: newIdentity,
+				context: context,
+				updateMessage: updateMessage
+			)
+		}
+	}
+
+	private func fixture(version: SemanticVersion) -> Fixture {
+		let knownAgent = AgentPrivateKey()
+		let newAgent = AgentPrivateKey()
+		let newIdentity = IdentityPrivateKey(algorithm: .curve25519).publicKey
+		let context = TypedDigest(prefix: .sha256, over: Data("group-context".utf8))
+		let updateMessage = Data("mls-leaf-node-update".utf8)
+		let agentData = AgentUpdate(version: version, isAppClip: false, addresses: [])
+		return .init(
+			knownAgent: knownAgent,
+			newAgent: newAgent,
+			newIdentity: newIdentity,
+			context: context,
+			updateMessage: updateMessage,
+			agentData: agentData,
+			tbs: .init(
+				knownAgentKey: knownAgent.publicKey,
+				newAgentIdentity: newIdentity,
+				context: context,
+				updateMessage: updateMessage,
+				agentData: agentData
+			)
+		)
+	}
+
+	// Below the threshold: no discriminator; body is the plain concatenation;
+	// and the handoff round-trips. This is today's classical wire format.
+	@Test func testSubThresholdOmitsDiscriminator() throws {
+		let f = fixture(version: .init(major: 2, minor: 2, patch: 0))
+		#expect(!f.agentData.domainSeparatesHandoff)
+
+		let body = try f.tbs.formatForSigning
+		#expect(!body.starts(with: AgentHandoff.NewAgentTBS.discriminator))
+		#expect(try body == f.plainBody)
+
+		#expect(try f.validate(f.signedHandoff()) == f.agentData)
+	}
+
+	// At/above the threshold: discriminator is prepended; the handoff round-trips.
+	@Test func testAtThresholdIncludesDiscriminator() throws {
+		let f = fixture(version: AgentUpdate.pqDomainSeparationVersion)
+		#expect(f.agentData.domainSeparatesHandoff)
+
+		let body = try f.tbs.formatForSigning
+		#expect(body.starts(with: AgentHandoff.NewAgentTBS.discriminator))
+		#expect(try body == AgentHandoff.NewAgentTBS.discriminator + f.plainBody)
+
+		#expect(try f.validate(f.signedHandoff()) == f.agentData)
+	}
+
+	// A signature over neither body is rejected (guards against a no-op verifier).
+	@Test func testUnrelatedSignatureRejected() throws {
+		let f = fixture(version: AgentUpdate.pqDomainSeparationVersion)
+		let bogus = try AgentHandoff(
+			first: f.agentData,
+			second: f.newAgent.signer(Data("not the handoff body".utf8))
+		)
+		#expect(throws: ProtocolError.authenticationError) {
+			_ = try f.validate(bogus)
+		}
+	}
+}

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
@@ -102,6 +102,35 @@ struct AgentHandoffDomainSeparationTests {
 		#expect(try f.validate(f.signedHandoff()) == f.agentData)
 	}
 
+	// The capability tier sits strictly between today's classical agent version
+	// (2.2.0) and the domain-separation threshold, so advertising PQ capability
+	// does not by itself flip the handoff format.
+	@Test func testCapabilityVersionOrdering() throws {
+		#expect(
+			AgentUpdate.pqCapableVersion
+				== SemanticVersion(major: 2, minor: 3, patch: 0)
+		)
+		#expect(
+			SemanticVersion(major: 2, minor: 2, patch: 0) < AgentUpdate.pqCapableVersion
+		)
+		#expect(AgentUpdate.pqCapableVersion < AgentUpdate.pqDomainSeparationVersion)
+	}
+
+	// At exactly the capability tier (2.3.0): the agent is PQ-capable, but the
+	// handoff body is still undiscriminated (== the plain concatenation) and the
+	// handoff round-trips. The capability tier must not trip the format switch.
+	@Test func testCapabilityTierOmitsDiscriminator() throws {
+		let f = fixture(version: AgentUpdate.pqCapableVersion)
+		#expect(f.agentData.isPQCapable)
+		#expect(!f.agentData.domainSeparatesHandoff)
+
+		let body = try f.tbs.formatForSigning
+		#expect(!body.starts(with: AgentHandoff.NewAgentTBS.discriminator))
+		#expect(try body == f.plainBody)
+
+		#expect(try f.validate(f.signedHandoff()) == f.agentData)
+	}
+
 	// A signature over neither body is rejected (guards against a no-op verifier).
 	@Test func testUnrelatedSignatureRejected() throws {
 		let f = fixture(version: AgentUpdate.pqDomainSeparationVersion)


### PR DESCRIPTION
`AgentHandoff.NewAgentTBS` is the one to-be-signed body in CommProtocol without a domain-separation discriminator. Rather than add it unconditionally (which needs its own coordinated rollout — a new signer breaks a not-yet-upgraded verifier), this gates it on `AgentUpdate.version`: agents at/above `AgentUpdate.pqDomainSeparationVersion` prepend the discriminator; classical (sub-threshold) agents keep the pre-separation body byte-for-byte. Both signer and verifier derive the choice from the version already inside the signed body, so it's deterministic and tamper-evident, and it rides the PQ **capability** version bump the app already plans (`AgentUpdate.version ≥ threshold`, per `pq-card-in-session-negotiation.md`) instead of a separate flag day.

The threshold is a placeholder (`3.0.0`, above today's `AgentVersions.current` = 2.2.0) so the change is **inert** until an app declares a ≥-threshold version; the constant is `public` so the app finalizes it in one place at the PQ release. The MLS suite itself (the literal PQ signal) isn't carried on the handoff path, which is why the version is the hook.

This also names the intermediate **`AgentUpdate.pqCapableVersion`** (`2.3.0`), the PQ *parse-capability* tier: an agent at this version advertises "I can speak PQ, come negotiate" while its handoff bodies stay undiscriminated (below `3.0.0`), so the classical wire format is unchanged. It splits capability cleanly from the format switch, giving a three-tier ladder — `≤2.2.0` legacy → `2.3.0` PQ-capable but non-separated → `3.0.0` domain-separated. Both constants are `public` so the app imports them as the single source of truth.

**App-side follow-up (out of scope here):** the app declares its agent version **per connection**, keyed on that connection's negotiated suite — `pqCapableVersion` (2.3.0) on classical connections (undiscriminated handoffs plus an in-band "I can speak PQ" signal, so an existing peer can trigger re-establishment without re-fetching published offers) and `pqDomainSeparationVersion` (3.0.0) on PQ connections (domain-separated handoffs). No per-peer inbound-version tracking is needed: a PQ connection only exists with a peer that already negotiated PQ, so the connection's suite *is* the capability confirmation. This supersedes the earlier per-peer "compatibility mode until an inbound version confirms the peer" sketch and avoids an app-wide flag day. The app imports both constants.

Supersedes the fallback-based approach previously in the hardening PR. Full suite green (45 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
