### PR TITLE
Add createAgentDelegate(for:context:) for a pre-minted agent key

### DIFF
--- a/.changeset/agent-delegate-for-existing-key.md
+++ b/.changeset/agent-delegate-for-existing-key.md
@@ -1,0 +1,15 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Add `IdentityPrivateKey.createAgentDelegate(for:context:)` — delegate this
+identity to an agent key the caller already holds, rather than minting one. The
+delegate binds only the agent's public key, so the caller keeps the private half.
+
+Needed when the agent key must be chosen before the delegation context is known:
+a post-quantum card session's receiver picks its new agent key up front (the
+session's `newClientId`), then learns the session proposal context only after the
+establishment handshake — the same-identity mirror of how an anchor's
+`createNewAgentHandoff` already accepts a pre-minted agent. The existing
+`createAgentDelegate(context:)` now routes through the new variant; behavior
+unchanged.

--- a/Sources/CommProtocol/IdentityKeys/IdentityKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/IdentityKeys.swift
@@ -83,19 +83,35 @@ public struct IdentityPrivateKey: Sendable {
 		IdentityDelegate
 	) {
 		let newAgent = AgentPrivateKey()
-		let newAgentPubKey = newAgent.publicKey
+		return (
+			newAgent,
+			try createAgentDelegate(for: newAgent.publicKey, context: context)
+		)
+	}
+
+	///Delegate this identity to an agent key the caller already holds, rather than
+	///minting one. The delegate binds only the agent's PUBLIC key (`agentID`) and
+	///`context`, so the private half is never needed here — the caller keeps it.
+	///
+	///Needed when the agent key must be chosen BEFORE the delegation context is
+	///known: e.g. a post-quantum card session's receiver picks its new agent key
+	///up front (the session's `newClientId`), then learns the session proposal
+	///context only after the establishment handshake — the mirror, for the
+	///same-identity delegate path, of how an anchor's `createNewAgentHandoff`
+	///already accepts a pre-minted `newAgent`.
+	public func createAgentDelegate(
+		for newAgentId: AgentPublicKey,
+		context: TypedDigest
+	) throws -> IdentityDelegate {
 		let signature = try sign(
 			input: IdentityDelegate.TBS(
-				agentID: newAgentPubKey.id,
+				agentID: newAgentId.id,
 				context: context
 			).formatForSigning
 		)
-		return (
-			newAgent,
-			.init(
-				newAgentId: newAgentPubKey,
-				knownIdentitySignature: signature
-			)
+		return .init(
+			newAgentId: newAgentId,
+			knownIdentitySignature: signature
 		)
 	}
 

--- a/Tests/CommProtocolTests/IdentityAgentDelegateTests.swift
+++ b/Tests/CommProtocolTests/IdentityAgentDelegateTests.swift
@@ -1,0 +1,76 @@
+//
+//  IdentityAgentDelegateTests.swift
+//  CommProtocol
+//
+//  Pins `IdentityPrivateKey.createAgentDelegate(for:context:)` — delegating an
+//  agent key the caller already holds. Needed when the agent key must be chosen
+//  before the delegation context is known (a PQ card session's receiver picks its
+//  `newClientId` up front, then learns the session proposal context only after
+//  the establishment handshake).
+//
+
+import CommProtocolMocks
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+struct IdentityAgentDelegateTests {
+	let identityKey: IdentityPrivateKey
+	let signedIdentity: SignedObject<CoreIdentity>
+
+	init() throws {
+		(identityKey, signedIdentity) = try Mocks.mockIdentity()
+	}
+
+	@Test func delegatesAPreMintedAgentKey() throws {
+		let context = try TypedDigest.mock()
+		//caller mints the agent key up front (the PQ-card `newClientId` case)
+		let newAgent = AgentPrivateKey()
+
+		let delegate = try identityKey.createAgentDelegate(
+			for: newAgent.publicKey,
+			context: context
+		)
+
+		//the delegate names the pre-minted key and validates under the identity
+		#expect(delegate.newAgentId == newAgent.publicKey)
+		let validated = try delegate.validate(
+			knownIdentity: signedIdentity.content.id,
+			context: context
+		)
+		#expect(validated == newAgent.publicKey)
+	}
+
+	@Test func rejectsWrongContext() throws {
+		let newAgent = AgentPrivateKey()
+		let delegate = try identityKey.createAgentDelegate(
+			for: newAgent.publicKey,
+			context: try TypedDigest.mock()
+		)
+		#expect(throws: (any Error).self) {
+			//validation under a different context must fail the signature check
+			_ = try delegate.validate(
+				knownIdentity: signedIdentity.content.id,
+				context: try TypedDigest.mock()
+			)
+		}
+	}
+
+	@Test func mintingVariantMatchesForVariant() throws {
+		//the minting convenience now routes through the pre-minted-key path, so a
+		//delegate built either way names and validates the same agent key
+		let context = try TypedDigest.mock()
+		let (minted, delegate) = try identityKey.createAgentDelegate(context: context)
+		let viaFor = try identityKey.createAgentDelegate(
+			for: minted.publicKey, context: context)
+
+		#expect(delegate.newAgentId == viaFor.newAgentId)
+		#expect(
+			try delegate.validate(
+				knownIdentity: signedIdentity.content.id, context: context)
+				== (try viaFor.validate(
+					knownIdentity: signedIdentity.content.id, context: context))
+		)
+	}
+}


### PR DESCRIPTION
Adds `IdentityPrivateKey.createAgentDelegate(for: AgentPublicKey, context:)` — delegate this identity to an agent key the caller already holds, instead of minting one.

**Why.** The existing same-identity `createAgentDelegate(context:)` mints the agent key *from* the delegation context, so the key can't be chosen before the context is known. A post-quantum card session's receiver needs exactly that ordering: it must pick its new agent key up front (the session's `newClientId` passed to `receiveCardWelcome`), then only learns the session proposal context *after* the establishment handshake. Today the app can't complete a PQ card receive because of this circular dependency — the anchor path already has the equivalent (`PrivateActiveAnchor.createNewAgentHandoff` accepts a pre-minted `newAgent`), but the same-identity card path did not.

**Safety.** No new crypto: the delegate binds only the agent's *public* key (`agentID`) + `context`, so the private half is never used here. The existing `createAgentDelegate(context:)` is refactored to mint a key and route through the new variant — behavior byte-unchanged, and the existing `CommProposalTests` (which exercise the minting path) still pass.

**Tests.** `IdentityAgentDelegateTests`: a pre-minted key validates under the identity + context; validation under a different context fails; the minting and pre-minted paths name/validate the same agent. Full `swift test` green; `swift format lint` clean; changeset included (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)