### PR TITLE
Add PQAnchorWelcome/PQAppWelcome carrying the bootstrap commitment

### DIFF
--- a/.changeset/date-wire-roundtrip-equality.md
+++ b/.changeset/date-wire-roundtrip-equality.md
@@ -10,11 +10,13 @@ away the low mantissa bit for ~half of current-era clock values — so
 and whole-struct equality across a wire round trip flaked per-run (bit
 PQAppWelcomeTests on PR #29).
 
-Adds `Date.wireNormalized` — the same instant pre-rounded to the wire grid
-(identical wire bytes, adjusted by at most 2⁻²³ s ≈ 120 ns) — and stamps it
-at every library constructor that bakes a Date into a wire struct
-(`sentTime`, succession proof dates), including the caller-supplied
-`NewAgentData.expiration`, which its init now normalizes. One parse is a
-fixed point, so normalized Dates survive any number of round trips
-`==`-intact. Wire bytes are unchanged; only in-memory sub-µs noise is
-removed. Normalize likewise if you feed a Date-typed wire field directly.
+Adds `WireDate` — a Date pre-rounded to the wire grid at construction
+(moving the instant by at most 2⁻²³ s ≈ 120 ns) — as the field type of
+every Date-carrying wire struct (`sentTime`, succession proof dates,
+`NewAgentData.expiration`), and removes `Date`'s own LinearEncodable
+conformance, so a raw-Date wire field no longer compiles. Wire bytes are
+unchanged and round trips are exact by construction; only in-memory sub-µs
+noise is removed. Source-breaking for field readers: take `.date` off a
+`WireDate` (Date-taking convenience inits are unchanged, e.g.
+`NewAgentData`'s). `Date.wireNormalized` exposes the same rounding for
+comparing a caller-held Date against a round-tripped `.date`.

--- a/.changeset/date-wire-roundtrip-equality.md
+++ b/.changeset/date-wire-roundtrip-equality.md
@@ -11,9 +11,10 @@ and whole-struct equality across a wire round trip flaked per-run (bit
 PQAppWelcomeTests on PR #29).
 
 Adds `Date.wireNormalized` — the same instant pre-rounded to the wire grid
-(identical wire bytes, < 1 ulp adjustment) — and stamps it at every library
-constructor that bakes a Date into a wire struct (`sentTime`, succession
-proof dates). One parse is a fixed point, so normalized Dates survive any
-number of round trips `==`-intact. Wire bytes are unchanged; only in-memory
-sub-µs noise is removed. Callers supplying their own Dates (expirations)
-should normalize likewise before comparing structs across a round trip.
+(identical wire bytes, adjusted by at most 2⁻²³ s ≈ 120 ns) — and stamps it
+at every library constructor that bakes a Date into a wire struct
+(`sentTime`, succession proof dates), including the caller-supplied
+`NewAgentData.expiration`, which its init now normalizes. One parse is a
+fixed point, so normalized Dates survive any number of round trips
+`==`-intact. Wire bytes are unchanged; only in-memory sub-µs noise is
+removed. Normalize likewise if you feed a Date-typed wire field directly.

--- a/.changeset/date-wire-roundtrip-equality.md
+++ b/.changeset/date-wire-roundtrip-equality.md
@@ -1,0 +1,19 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Make wire-bound Dates round-trip to exact equality. The wire format stores
+`timeIntervalSince1970.bitPattern`, but `Date` equates on
+`timeIntervalSinceReferenceDate`, and the epoch conversion in Double rounds
+away the low mantissa bit for ~half of current-era clock values — so
+`parse(wireFormat) == original` was a coin flip for any Date stamped `.now`,
+and whole-struct equality across a wire round trip flaked per-run (bit
+PQAppWelcomeTests on PR #29).
+
+Adds `Date.wireNormalized` — the same instant pre-rounded to the wire grid
+(identical wire bytes, < 1 ulp adjustment) — and stamps it at every library
+constructor that bakes a Date into a wire struct (`sentTime`, succession
+proof dates). One parse is a fixed point, so normalized Dates survive any
+number of round trips `==`-intact. Wire bytes are unchanged; only in-memory
+sub-µs noise is removed. Callers supplying their own Dates (expirations)
+should normalize likewise before comparing structs across a round trip.

--- a/.changeset/pq-welcome-structs.md
+++ b/.changeset/pq-welcome-structs.md
@@ -1,0 +1,21 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Add `PQAnchorWelcome` / `PQAppWelcome`: parallel establishment-reply structs for
+the PQ (TwoMLSPQ v20) path. The classical `AnchorWelcome` / `AppWelcome` stay
+live unchanged — routing discriminates (the PQ reply only ever answers a PQ
+hello), so there is no version field.
+
+Both carry the new `PQEstablishmentKeyMaterial` pair inside the signed body:
+the replier's CLASSICAL return key package plus a `TypedDigest` commitment
+(SHA-256) to the A.4 bootstrap PQ key package, binding the deferred PQ key
+material to the sender's identity root. New signature discriminators
+("PQAnchorReply.*") domain-separate the anchor arm from the classical welcome;
+the card arm's content layout diverges structurally at the fifth element.
+
+New API: `PrivateActiveAnchor.createPQAnchorWelcome`,
+`AnchorPublicKey.verify(pqReply:recipient:)`,
+`AgentPrivateKey.createPQAppWelcome`, `PQAppWelcome.validated(myAgent:)`,
+plus `PQAppWelcome.mock` / `PQEstablishmentKeyMaterial.mock` in
+CommProtocolMocks.

--- a/Sources/CommProtocol/Anchors/AnchorSuccession.swift
+++ b/Sources/CommProtocol/Anchors/AnchorSuccession.swift
@@ -52,10 +52,10 @@ extension AnchorSuccession.Proof: LinearEncodedPair {
 
 //save the date alongside the Proof so we can apply policy to prune
 public struct DatedProof: LinearEncodedPair, Sendable {
-	public var first: AnchorSuccession.Proof
-	public var second: Date
+	public let first: AnchorSuccession.Proof
+	public let second: WireDate
 
-	public init(first: AnchorSuccession.Proof, second: Date) {
+	public init(first: AnchorSuccession.Proof, second: WireDate) {
 		self.first = first
 		self.second = second
 	}

--- a/Sources/CommProtocol/Anchors/Exchange/AnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/AnchorWelcome.swift
@@ -32,13 +32,13 @@ extension AnchorWelcome {
 	public struct Welcome: LinearEncodedQuad, Sendable {
 		public let first: AgentUpdate
 		public let second: UInt32  //seqNo
-		public let third: Date
+		public let third: WireDate
 		public let fourth: Data  //keyPackage
 
 		public init(
 			first: AgentUpdate,
 			second: UInt32,
-			third: Date,
+			third: WireDate,
 			fourth: Data
 		) {
 			self.first = first

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -1,0 +1,313 @@
+//
+//  PQAnchorWelcome.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import Foundation
+
+///The PQ (TwoMLSPQ) establishment reply: a separate, parallel structure to
+///`AnchorWelcome`, which stays live unchanged on the classical path. No version
+///field — routing discriminates (this reply only ever answers a PQ hello, so
+///the recipient knows which struct to parse from the route, not the bytes).
+///
+///Differences from `AnchorWelcome`:
+/// - the welcome carries `PQEstablishmentKeyMaterial`: the replier's CLASSICAL
+///   return key package plus the commitment to the A.4 bootstrap PQ key package
+///   (see that type for the binding rationale)
+///
+///Signature bodies use fresh discriminators ("PQAnchorReply.*"), so a signature
+///over a classical `AnchorWelcome` can never validate as a `PQAnchorWelcome`,
+///or vice versa.
+///
+///Same pattern as AnchorHello/AnchorWelcome:
+///- Inner content that we are transmitting
+///- Signatures constructed from the content, maybe with additional context
+///- Wrap those in one data structure signed with the known key
+///- Mix in additional context as needed when verifying the outer signature
+public struct PQAnchorWelcome: LinearEncodedPair, Sendable {
+	public let first: TypedSignature
+	public let second: Data  //Package.wireformat
+
+	public init(first: TypedSignature, second: Data) {
+		self.first = first
+		self.second = second
+	}
+}
+
+extension PQAnchorWelcome {
+	public struct Welcome: Sendable {
+		public let agentUpdate: AgentUpdate
+		public let seqNo: UInt32
+		public let sentTime: Date
+		public let keyMaterial: PQEstablishmentKeyMaterial
+
+		public init(
+			agentUpdate: AgentUpdate,
+			seqNo: UInt32,
+			sentTime: Date,
+			keyMaterial: PQEstablishmentKeyMaterial
+		) {
+			self.agentUpdate = agentUpdate
+			self.seqNo = seqNo
+			self.sentTime = sentTime
+			self.keyMaterial = keyMaterial
+		}
+	}
+
+	public struct Content: Sendable {
+		public let attestation: DependentIdentity  //sender
+		public let agentKeyMaterial: TypedKeyMaterial  //AgentPublicKey
+		public let welcome: Welcome
+		public let mlsWelcomeData: Data
+
+		public init(
+			attestation: DependentIdentity,
+			agentKeyMaterial: TypedKeyMaterial,
+			welcome: Welcome,
+			mlsWelcomeData: Data
+		) {
+			self.attestation = attestation
+			self.agentKeyMaterial = agentKeyMaterial
+			self.welcome = welcome
+			self.mlsWelcomeData = mlsWelcomeData
+		}
+
+		func agentSignatureBody(
+			recipient: PublicAnchor
+		) -> AgentSignatureBody {
+			.init(
+				first: PQAnchorWelcome.AgentSignatureBody.discriminator,
+				second: self,
+				third: recipient
+			)
+		}
+	}
+
+	struct Package: LinearEncodedPair {
+		let first: Content  //Content.wireformat
+		let second: TypedSignature  //delegated agent signature
+
+		init(first: Content, second: TypedSignature) {
+			self.first = first
+			self.second = second
+		}
+	}
+
+	struct AgentSignatureBody: LinearEncodedTriple {
+		static let discriminator = "PQAnchorReply.AgentSignatureBody"
+		let first: String  //discriminator maps 1:1 to the delegation type
+		let second: Content
+		//injected context for the recipient
+		let third: PublicAnchor
+
+		init(first: String, second: Content, third: PublicAnchor) {
+			self.first = first
+			self.second = second
+			self.third = third
+		}
+	}
+
+	struct AnchorSignatureBody: LinearEncodedQuad {
+		static let discriminator = "PQAnchorReply.AnchorSignatureBody"
+		let first: String  //discriminator maps 1:1 to the delegation type
+		let second: Data  //Package.wireformat
+		let third: TypedKeyMaterial  //sender AnchorPublicKey
+		//injected context for the recipient
+		let fourth: PublicAnchor
+
+		init(
+			first: String,
+			second: Data,
+			third: TypedKeyMaterial,
+			fourth: PublicAnchor,
+		) {
+			self.first = first
+			self.second = second
+			self.third = third
+			self.fourth = fourth
+		}
+
+		init(
+			encodedPackage: Data,
+			knownAnchor: AnchorPublicKey,
+			recipient: PublicAnchor,
+		) {
+			self.init(
+				first: Self.discriminator,
+				second: encodedPackage,
+				third: knownAnchor.archive,
+				fourth: recipient,
+			)
+		}
+	}
+
+	public struct Verified: Sendable {
+		public let agent: PublicAnchorAgent
+		public let welcome: Welcome
+		public let mlsWelcomeData: Data
+	}
+}
+
+extension PQAnchorWelcome.Welcome: LinearEncodedQuad {
+	public var first: AgentUpdate { agentUpdate }
+	public var second: UInt32 { seqNo }
+	public var third: Date { sentTime }
+	public var fourth: PQEstablishmentKeyMaterial { keyMaterial }
+
+	public init(
+		first: AgentUpdate,
+		second: UInt32,
+		third: Date,
+		fourth: PQEstablishmentKeyMaterial
+	) throws {
+		self.init(
+			agentUpdate: first,
+			seqNo: second,
+			sentTime: third,
+			keyMaterial: fourth
+		)
+	}
+}
+
+extension PQAnchorWelcome.Content: LinearEncodedQuad {
+	public var first: DependentIdentity { attestation }
+	public var second: TypedKeyMaterial { agentKeyMaterial }
+	public var third: PQAnchorWelcome.Welcome { welcome }
+	public var fourth: Data { mlsWelcomeData }
+
+	public init(
+		first: DependentIdentity,
+		second: TypedKeyMaterial,
+		third: PQAnchorWelcome.Welcome,
+		fourth: Data
+	) throws {
+		self.init(
+			attestation: first,
+			agentKeyMaterial: second,
+			welcome: third,
+			mlsWelcomeData: fourth
+		)
+	}
+}
+
+extension PrivateActiveAnchor {
+	//agent isn't bound to the anchor until this step
+	//so we expect the client to generate a fresh agent (no reuse)
+	//generate an mlsWelcome, and provide them as input here
+	public func createPQAnchorWelcome(
+		agentUpdate: AgentUpdate,
+		keyMaterial: PQEstablishmentKeyMaterial,
+		mlsWelcomeMessage: Data,
+		newAgentKey: AgentPrivateKey,
+		recipient: PublicAnchor,
+		newSeqNo: UInt32
+	) throws -> (PrivateAnchorAgent, PQAnchorWelcome, PQAnchorWelcome.Content) {
+		let content = PQAnchorWelcome.Content(
+			attestation: attestation,
+			agentKeyMaterial: newAgentKey.publicKey.id,
+			welcome: .init(
+				agentUpdate: agentUpdate,
+				seqNo: newSeqNo,
+				sentTime: .now,
+				keyMaterial: keyMaterial
+			),
+			mlsWelcomeData: mlsWelcomeMessage
+		)
+
+		let package = PQAnchorWelcome.Package(
+			first: content,
+			second:
+				try newAgentKey
+				.signer(
+					content
+						.agentSignatureBody(recipient: recipient)
+						.wireFormat
+				)
+		)
+
+		let outerSignature = try privateKey.signer(
+			try PQAnchorWelcome.AnchorSignatureBody(
+				encodedPackage: try package.wireFormat,
+				knownAnchor: publicKey,
+				recipient: recipient,
+			).wireFormat
+		)
+
+		let reply = PQAnchorWelcome(
+			first: outerSignature,
+			second: try package.wireFormat
+		)
+
+		return (
+			.init(
+				privateKey: newAgentKey,
+				source: .reply
+			),
+			reply,
+			content
+		)
+	}
+}
+
+extension AnchorPublicKey {
+	public func verify(
+		pqReply: PQAnchorWelcome,
+		recipient: PublicAnchor
+	) throws -> PQAnchorWelcome.Verified {
+		let verifiedPackage = try verifyPackage(
+			pqReply: pqReply,
+			recipient: recipient,
+		)
+		let newAgentKey = try AgentPublicKey(
+			archive: verifiedPackage.first.agentKeyMaterial
+		)
+
+		let agentSignatureBody = try verifiedPackage.first
+			.agentSignatureBody(recipient: recipient)
+			.wireFormat
+
+		guard
+			newAgentKey.verifier(
+				verifiedPackage.second,
+				agentSignatureBody
+			)
+		else {
+			throw ProtocolError.authenticationError
+		}
+		let content = verifiedPackage.first
+
+		return .init(
+			agent: .init(
+				anchor: .init(
+					publicKey: self,
+					attestation: content.attestation
+				),
+				agentKey: newAgentKey
+			),
+			welcome: content.welcome,
+			mlsWelcomeData: content.mlsWelcomeData
+		)
+	}
+
+	private func verifyPackage(
+		pqReply: PQAnchorWelcome,
+		recipient: PublicAnchor,
+	) throws -> PQAnchorWelcome.Package {
+		guard
+			verifier(
+				pqReply.first,
+				try PQAnchorWelcome.AnchorSignatureBody(
+					encodedPackage: pqReply.second,
+					knownAnchor: self,
+					recipient: recipient,
+				).wireFormat
+			)
+		else {
+			throw ProtocolError.authenticationError
+		}
+
+		return try .finalParse(pqReply.second)
+	}
+}

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -199,7 +199,7 @@ extension PrivateActiveAnchor {
 			welcome: .init(
 				agentUpdate: agentUpdate,
 				seqNo: newSeqNo,
-				sentTime: .now,
+				sentTime: .now.wireNormalized,
 				keyMaterial: keyMaterial
 			),
 			mlsWelcomeData: mlsWelcomeMessage

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -88,11 +88,6 @@ extension PQAnchorWelcome {
 	struct Package: LinearEncodedPair {
 		let first: Content  //Content.wireformat
 		let second: TypedSignature  //delegated agent signature
-
-		init(first: Content, second: TypedSignature) {
-			self.first = first
-			self.second = second
-		}
 	}
 
 	struct AgentSignatureBody: LinearEncodedTriple {
@@ -101,12 +96,6 @@ extension PQAnchorWelcome {
 		let second: Content
 		//injected context for the recipient
 		let third: PublicAnchor
-
-		init(first: String, second: Content, third: PublicAnchor) {
-			self.first = first
-			self.second = second
-			self.third = third
-		}
 	}
 
 	struct AnchorSignatureBody: LinearEncodedQuad {

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -43,13 +43,13 @@ extension PQAnchorWelcome {
 		//deliberately kept for template parity with AnchorWelcome (ruling
 		//2026-07-17): an unauthenticated sender assertion no consumer reads
 		//today — do not trust it for anything without adding validation
-		public let sentTime: Date
+		public let sentTime: WireDate
 		public let keyMaterial: PQEstablishmentKeyMaterial
 
 		public init(
 			agentUpdate: AgentUpdate,
 			seqNo: UInt32,
-			sentTime: Date,
+			sentTime: WireDate,
 			keyMaterial: PQEstablishmentKeyMaterial
 		) {
 			self.agentUpdate = agentUpdate
@@ -145,13 +145,13 @@ extension PQAnchorWelcome {
 extension PQAnchorWelcome.Welcome: LinearEncodedQuad {
 	public var first: AgentUpdate { agentUpdate }
 	public var second: UInt32 { seqNo }
-	public var third: Date { sentTime }
+	public var third: WireDate { sentTime }
 	public var fourth: PQEstablishmentKeyMaterial { keyMaterial }
 
 	public init(
 		first: AgentUpdate,
 		second: UInt32,
-		third: Date,
+		third: WireDate,
 		fourth: PQEstablishmentKeyMaterial
 	) throws {
 		self.init(
@@ -202,7 +202,7 @@ extension PrivateActiveAnchor {
 			welcome: .init(
 				agentUpdate: agentUpdate,
 				seqNo: newSeqNo,
-				sentTime: .now.wireNormalized,
+				sentTime: .now,
 				keyMaterial: keyMaterial
 			),
 			mlsWelcomeData: mlsWelcomeMessage

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -40,6 +40,9 @@ extension PQAnchorWelcome {
 	public struct Welcome: Sendable {
 		public let agentUpdate: AgentUpdate
 		public let seqNo: UInt32
+		//deliberately kept for template parity with AnchorWelcome (ruling
+		//2026-07-17): an unauthenticated sender assertion no consumer reads
+		//today — do not trust it for anything without adding validation
 		public let sentTime: Date
 		public let keyMaterial: PQEstablishmentKeyMaterial
 

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -67,7 +67,7 @@ public struct PrivateActiveAnchor: Sendable {
 						predecessor: publicKey.archive,
 						signature: signature
 					),
-					second: .now.wireNormalized
+					second: .now
 				)
 			]
 		)
@@ -167,7 +167,7 @@ extension PrivateActiveAnchor {
 		}
 
 		let filteredHistory = helloInputs.proofHistory
-			.filter { historyFilter($0.second) }
+			.filter { historyFilter($0.second.date) }
 			.map { $0.first }
 
 		let content = AnchorHello.Content(
@@ -220,7 +220,7 @@ extension PrivateActiveAnchor {
 			third: .init(
 				first: agentUpdate,
 				second: newSeqNo,
-				third: .now.wireNormalized,
+				third: .now,
 				fourth: keyPackageData
 			),
 			fourth: mlsWelcomeMessage

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -67,7 +67,7 @@ public struct PrivateActiveAnchor: Sendable {
 						predecessor: publicKey.archive,
 						signature: signature
 					),
-					second: .now
+					second: .now.wireNormalized
 				)
 			]
 		)
@@ -220,7 +220,7 @@ extension PrivateActiveAnchor {
 			third: .init(
 				first: agentUpdate,
 				second: newSeqNo,
-				third: .now,
+				third: .now.wireNormalized,
 				fourth: keyPackageData
 			),
 			fourth: mlsWelcomeMessage

--- a/Sources/CommProtocol/IdentityExchange/AgentHello.swift
+++ b/Sources/CommProtocol/IdentityExchange/AgentHello.swift
@@ -19,7 +19,7 @@ public struct AgentHello: Sendable {
 		//prepend the identity key when signing
 		public let agentUpdate: AgentUpdate
 		public let keyChoices: SessionIntroductionChoices
-		public let expiration: Date
+		public let expiration: WireDate
 
 		public init(
 			agentUpdate: AgentUpdate,
@@ -28,9 +28,7 @@ public struct AgentHello: Sendable {
 		) {
 			self.agentUpdate = agentUpdate
 			self.keyChoices = keyChoices
-			//pre-round to the wire grid so a wire round trip preserves ==
-			//(see the note on `Date: LinearEncodable`)
-			self.expiration = expiration.wireNormalized
+			self.expiration = .init(date: expiration)
 		}
 
 		//fold in the identity key when we sign it
@@ -111,17 +109,17 @@ extension AgentHello: LinearEncodedPair {
 extension AgentHello.NewAgentData: LinearEncodedTriple {
 	public var first: AgentUpdate { agentUpdate }
 	public var second: SessionIntroductionChoices { keyChoices }
-	public var third: Date { expiration }
+	public var third: WireDate { expiration }
 
 	public init(
 		first: AgentUpdate,
 		second: SessionIntroductionChoices,
-		third: Date
+		third: WireDate
 	) throws {
 		self.init(
 			agentUpdate: first,
 			keyChoices: second,
-			expiration: third
+			expiration: third.date
 		)
 	}
 }

--- a/Sources/CommProtocol/IdentityExchange/AgentHello.swift
+++ b/Sources/CommProtocol/IdentityExchange/AgentHello.swift
@@ -28,7 +28,9 @@ public struct AgentHello: Sendable {
 		) {
 			self.agentUpdate = agentUpdate
 			self.keyChoices = keyChoices
-			self.expiration = expiration
+			//pre-round to the wire grid so a wire round trip preserves ==
+			//(see the note on `Date: LinearEncodable`)
+			self.expiration = expiration.wireNormalized
 		}
 
 		//fold in the identity key when we sign it

--- a/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
@@ -25,7 +25,7 @@ public struct AppWelcome: Equatable {
 		public let groupId: DataIdentifier
 		public let agentData: AgentUpdate
 		public let seqNo: UInt32  //sets the initial seqNo
-		public let sentTime: Date  //just as messages assert local send time
+		public let sentTime: WireDate  //just as messages assert local send time
 		public let keyPackageData: Data
 	}
 
@@ -57,14 +57,14 @@ extension AppWelcome.Content: LinearEncodedQuintuple {
 	public var first: DataIdentifier { groupId }
 	public var second: AgentUpdate { agentData }
 	public var third: UInt32 { seqNo }
-	public var fourth: Date { sentTime }
+	public var fourth: WireDate { sentTime }
 	public var fifth: Data { keyPackageData }
 
 	public init(
 		first: DataIdentifier,
 		second: AgentUpdate,
 		third: UInt32,
-		fourth: Date,
+		fourth: WireDate,
 		fifth: Data
 	) throws {
 		self.init(

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -27,7 +27,10 @@ public struct PQAppWelcome: Equatable, Sendable {
 		public let groupId: DataIdentifier
 		public let agentData: AgentUpdate
 		public let seqNo: UInt32  //sets the initial seqNo
-		public let sentTime: Date  //just as messages assert local send time
+		//just as messages assert local send time; kept for template parity
+		//with AppWelcome (ruling 2026-07-17) — an unauthenticated sender
+		//assertion no consumer reads today
+		public let sentTime: Date
 		public let keyMaterial: PQEstablishmentKeyMaterial
 	}
 

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -1,0 +1,156 @@
+//
+//  PQAppWelcome.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import CryptoKit
+import Foundation
+
+///The PQ (TwoMLSPQ) card establishment reply: a separate, parallel structure to
+///`AppWelcome`, which stays live unchanged on the classical path. No version
+///field — routing discriminates (this reply only ever answers a PQ card offer,
+///so the recipient knows which struct to parse from the route).
+///
+///Like `AppWelcome`, this is the application-level data accompanying an MLS
+///welcome issued in response to a key package; the difference is the signed
+///content carries `PQEstablishmentKeyMaterial` (the CLASSICAL return key
+///package plus the commitment to the A.4 bootstrap PQ key package) instead of
+///a bare key-package blob. The layouts also diverge structurally at the fifth
+///content element (nested pair vs Data), so the signed wire bytes of one never
+///parse as the other.
+public struct PQAppWelcome: Equatable {
+	public let introduction: IdentityIntroduction
+	public let signedContent: SignedObject<Content>
+
+	public struct Content: Equatable, Sendable {
+		public let groupId: DataIdentifier
+		public let agentData: AgentUpdate
+		public let seqNo: UInt32  //sets the initial seqNo
+		public let sentTime: Date  //just as messages assert local send time
+		public let keyMaterial: PQEstablishmentKeyMaterial
+	}
+
+	//This gets transmitted, encrypted to the HPKE init key
+	public struct Combined: Equatable {
+		public let appWelcome: PQAppWelcome
+		public let mlsWelcomeData: Data
+
+		public init(appWelcome: PQAppWelcome, mlsMessageData: Data) {
+			self.appWelcome = appWelcome
+			self.mlsWelcomeData = mlsMessageData
+		}
+	}
+}
+
+extension PQAppWelcome: LinearEncodedPair {
+	public var first: IdentityIntroduction { introduction }
+	public var second: SignedObject<Content> { signedContent }
+
+	public init(
+		first: IdentityIntroduction,
+		second: SignedObject<Content>
+	) throws {
+		self.init(introduction: first, signedContent: second)
+	}
+}
+
+extension PQAppWelcome.Content: LinearEncodedQuintuple {
+	public var first: DataIdentifier { groupId }
+	public var second: AgentUpdate { agentData }
+	public var third: UInt32 { seqNo }
+	public var fourth: Date { sentTime }
+	public var fifth: PQEstablishmentKeyMaterial { keyMaterial }
+
+	public init(
+		first: DataIdentifier,
+		second: AgentUpdate,
+		third: UInt32,
+		fourth: Date,
+		fifth: PQEstablishmentKeyMaterial
+	) throws {
+		self.init(
+			groupId: first,
+			agentData: second,
+			seqNo: third,
+			sentTime: fourth,
+			keyMaterial: fifth
+		)
+	}
+}
+
+extension PQAppWelcome.Combined: LinearEncodedPair {
+	public var first: PQAppWelcome { appWelcome }
+	public var second: Data { mlsWelcomeData }
+
+	public init(first: PQAppWelcome, second: Data) throws {
+		self.init(appWelcome: first, mlsMessageData: second)
+	}
+}
+
+//The PQAppWelcome is encrypted to an assumed published key in HPKE basic mode
+//(we don't know the sender ahead of time)
+//should presume confidentiality but not authenticity.
+//We need to confirm the identity key in the PQAppWelcome signs
+//over the remainder of the data in the PQAppWelcome
+//some indirectly through the delegate AgentKey
+extension PQAppWelcome {
+	public struct Validated {
+		public let coreIdentity: CoreIdentity
+		public let introContents: IdentityIntroduction.Contents
+		public let imageResource: Resource
+		public let welcomeContent: PQAppWelcome.Content
+	}
+
+	public func validated(myAgent: AgentPublicKey) throws -> Validated {
+		let agentType = AgentTypes.welcome(
+			remoteAgentId: myAgent,
+			groupId: signedContent.content.groupId
+		)
+
+		guard
+			let context = try agentType.generateContext(
+				myAgentId: introduction.signedContents.content.agentKey
+			)
+		else {
+			throw ProtocolError.unexpected("mismatched context")
+		}
+
+		let (coreIdentity, introContents, imageResource) =
+			try introduction
+			.validated(context: context)
+
+		return .init(
+			coreIdentity: coreIdentity,
+			introContents: introContents,
+			imageResource: imageResource,
+			welcomeContent: try introContents.agentKey
+				.validate(signedObject: signedContent)
+		)
+	}
+}
+
+extension AgentPrivateKey {
+	public func createPQAppWelcome(
+		introduction: IdentityIntroduction,
+		agentData: AgentUpdate,
+		groupId: DataIdentifier,
+		keyMaterial: PQEstablishmentKeyMaterial
+	) throws -> PQAppWelcome {
+		let content = PQAppWelcome.Content(
+			groupId: groupId,
+			agentData: agentData,
+			seqNo: .random(in: .min...(.max)),
+			sentTime: .now,
+			keyMaterial: keyMaterial
+		)
+
+		let signedContent = try sign(content: content)
+
+		return .init(
+			introduction: introduction,
+			signedContent: signedContent
+		)
+	}
+}

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -5,7 +5,6 @@
 //  Created by Mark @ Germ on 7/17/26.
 //
 
-import CryptoKit
 import Foundation
 
 ///The PQ (TwoMLSPQ) card establishment reply: a separate, parallel structure to
@@ -20,7 +19,7 @@ import Foundation
 ///a bare key-package blob. The layouts also diverge structurally at the fifth
 ///content element (nested pair vs Data), so the signed wire bytes of one never
 ///parse as the other.
-public struct PQAppWelcome: Equatable {
+public struct PQAppWelcome: Equatable, Sendable {
 	public let introduction: IdentityIntroduction
 	public let signedContent: SignedObject<Content>
 
@@ -33,7 +32,7 @@ public struct PQAppWelcome: Equatable {
 	}
 
 	//This gets transmitted, encrypted to the HPKE init key
-	public struct Combined: Equatable {
+	public struct Combined: Equatable, Sendable {
 		public let appWelcome: PQAppWelcome
 		public let mlsWelcomeData: Data
 
@@ -96,7 +95,7 @@ extension PQAppWelcome.Combined: LinearEncodedPair {
 //over the remainder of the data in the PQAppWelcome
 //some indirectly through the delegate AgentKey
 extension PQAppWelcome {
-	public struct Validated {
+	public struct Validated: Sendable {
 		public let coreIdentity: CoreIdentity
 		public let introContents: IdentityIntroduction.Contents
 		public let imageResource: Resource

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -30,7 +30,7 @@ public struct PQAppWelcome: Equatable, Sendable {
 		//just as messages assert local send time; kept for template parity
 		//with AppWelcome (ruling 2026-07-17) — an unauthenticated sender
 		//assertion no consumer reads today
-		public let sentTime: Date
+		public let sentTime: WireDate
 		public let keyMaterial: PQEstablishmentKeyMaterial
 	}
 
@@ -62,14 +62,14 @@ extension PQAppWelcome.Content: LinearEncodedQuintuple {
 	public var first: DataIdentifier { groupId }
 	public var second: AgentUpdate { agentData }
 	public var third: UInt32 { seqNo }
-	public var fourth: Date { sentTime }
+	public var fourth: WireDate { sentTime }
 	public var fifth: PQEstablishmentKeyMaterial { keyMaterial }
 
 	public init(
 		first: DataIdentifier,
 		second: AgentUpdate,
 		third: UInt32,
-		fourth: Date,
+		fourth: WireDate,
 		fifth: PQEstablishmentKeyMaterial
 	) throws {
 		self.init(
@@ -144,7 +144,7 @@ extension AgentPrivateKey {
 			groupId: groupId,
 			agentData: agentData,
 			seqNo: .random(in: .min...(.max)),
-			sentTime: .now.wireNormalized,
+			sentTime: .now,
 			keyMaterial: keyMaterial
 		)
 

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -141,7 +141,7 @@ extension AgentPrivateKey {
 			groupId: groupId,
 			agentData: agentData,
 			seqNo: .random(in: .min...(.max)),
-			sentTime: .now,
+			sentTime: .now.wireNormalized,
 			keyMaterial: keyMaterial
 		)
 

--- a/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
@@ -97,7 +97,7 @@ public struct AgentPrivateKey: Sendable {
 				groupIdSeed: groupIdSeed,
 				agentSignatureWelcome: signature,
 				seqNo: .random(in: .min...(.max)),
-				sentTime: .now.wireNormalized
+				sentTime: .now
 			)
 		)
 	}
@@ -112,7 +112,7 @@ public struct AgentPrivateKey: Sendable {
 			groupId: groupId,
 			agentData: agentData,
 			seqNo: .random(in: .min...(.max)),
-			sentTime: .now.wireNormalized,
+			sentTime: .now,
 			keyPackageData: keyPackageData
 		)
 
@@ -140,7 +140,7 @@ public struct AgentPrivateKey: Sendable {
 				groupIdSeed: groupIdSeed,
 				agentSignatureWelcome: signature,
 				seqNo: .random(in: .min...(.max)),
-				sentTime: .now.wireNormalized
+				sentTime: .now
 			)
 		)
 	}

--- a/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
@@ -97,7 +97,7 @@ public struct AgentPrivateKey: Sendable {
 				groupIdSeed: groupIdSeed,
 				agentSignatureWelcome: signature,
 				seqNo: .random(in: .min...(.max)),
-				sentTime: .init()
+				sentTime: .now.wireNormalized
 			)
 		)
 	}
@@ -112,7 +112,7 @@ public struct AgentPrivateKey: Sendable {
 			groupId: groupId,
 			agentData: agentData,
 			seqNo: .random(in: .min...(.max)),
-			sentTime: .now,
+			sentTime: .now.wireNormalized,
 			keyPackageData: keyPackageData
 		)
 
@@ -140,7 +140,7 @@ public struct AgentPrivateKey: Sendable {
 				groupIdSeed: groupIdSeed,
 				agentSignatureWelcome: signature,
 				seqNo: .random(in: .min...(.max)),
-				sentTime: .init()
+				sentTime: .now.wireNormalized
 			)
 		)
 	}

--- a/Sources/CommProtocol/Objects/Dates.swift
+++ b/Sources/CommProtocol/Objects/Dates.swift
@@ -11,18 +11,27 @@ import Foundation
 
 ///The wire format stores `timeIntervalSince1970.bitPattern`, but `Date` equates on
 ///`timeIntervalSinceReferenceDate`, and converting between the two epochs in Double
-///rounds away the low mantissa bit for about half of current-era clock values.
-///So for an arbitrary in-memory Date (e.g. `.now`), `parse(wireFormat) == original`
-///is a coin flip — never compare un-normalized Dates (or structs containing them)
-///bit-exactly across a wire round trip.
+///can round away low mantissa bits (it does for about half of current-era clock
+///values). So for an arbitrary in-memory Date (e.g. `.now`),
+///`parse(wireFormat) == original` is a coin flip — never compare un-normalized
+///Dates (or structs containing them) bit-exactly across a wire round trip.
 ///
-///One round trip is a fixed point: the parsed Date re-encodes to identical bytes
-///and stays `==` through further round trips. `wireNormalized` applies that
-///rounding up front (identical wire bytes, adjusts the value by < 1 ulp, ~120 ns
-///today), so a Date stamped `.now.wireNormalized` round-trips to exact equality.
-///Library constructors stamp their wire-bound Dates this way; do the same with
-///any Date you supply to a wire-encoded struct (e.g. expirations) if you need
-///`==` across an encode/parse cycle. DateEncodingTests sweeps these properties.
+///For the timestamps this library stamps, one round trip is a fixed point: the
+///parsed Date re-encodes to identical bytes and stays `==` through further round
+///trips. `wireNormalized` applies that rounding up front — identical wire bytes,
+///moving the instant by at most 2⁻²³ s (~120 ns for current-era dates) — so a
+///Date stamped `.now.wireNormalized` round-trips to exact equality. Library
+///constructors stamp their wire-bound Dates this way (`NewAgentData`'s init
+///normalizes its caller-supplied expiration); normalize likewise if you feed a
+///Date-typed wire field directly. `RoundedDate` fields, like the
+///Resource/ProtocolAddress expirations, quantize to whole hours instead —
+///`wireNormalized` is inert there.
+///
+///Caveats at the edges: bytes from a foreign encoder can need a second parse to
+///reach the fixed point, `parse` does no finiteness check (NaN/±inf bit patterns
+///parse into Dates that poison comparisons), and Dates within 2⁻²⁴ s of the
+///reference epoch collapse onto it. DateEncodingTests sweeps these properties
+///across the distinct float-grid regimes.
 extension Date: LinearEncodable {
 	public static func parse(_ input: Data) throws -> (Date, Int) {
 		let (bitPattern, consumed) = try UInt64.parse(input)
@@ -43,7 +52,8 @@ extension Date: LinearEncodable {
 
 extension Date {
 	///Self, pre-rounded to what the wire format can represent, so that a wire
-	///round trip reproduces it exactly (see the note on `Date: LinearEncodable`)
+	///round trip reproduces a finite Date exactly (see the note on
+	///`Date: LinearEncodable`)
 	public var wireNormalized: Date {
 		.init(timeIntervalSince1970: timeIntervalSince1970)
 	}

--- a/Sources/CommProtocol/Objects/Dates.swift
+++ b/Sources/CommProtocol/Objects/Dates.swift
@@ -9,7 +9,20 @@ import Foundation
 
 //two different formats for dates
 
-//we transform the date into a
+///The wire format stores `timeIntervalSince1970.bitPattern`, but `Date` equates on
+///`timeIntervalSinceReferenceDate`, and converting between the two epochs in Double
+///rounds away the low mantissa bit for about half of current-era clock values.
+///So for an arbitrary in-memory Date (e.g. `.now`), `parse(wireFormat) == original`
+///is a coin flip — never compare un-normalized Dates (or structs containing them)
+///bit-exactly across a wire round trip.
+///
+///One round trip is a fixed point: the parsed Date re-encodes to identical bytes
+///and stays `==` through further round trips. `wireNormalized` applies that
+///rounding up front (identical wire bytes, adjusts the value by < 1 ulp, ~120 ns
+///today), so a Date stamped `.now.wireNormalized` round-trips to exact equality.
+///Library constructors stamp their wire-bound Dates this way; do the same with
+///any Date you supply to a wire-encoded struct (e.g. expirations) if you need
+///`==` across an encode/parse cycle. DateEncodingTests sweeps these properties.
 extension Date: LinearEncodable {
 	public static func parse(_ input: Data) throws -> (Date, Int) {
 		let (bitPattern, consumed) = try UInt64.parse(input)
@@ -25,6 +38,14 @@ extension Date: LinearEncodable {
 
 	public var wireFormat: Data {
 		timeIntervalSince1970.bitPattern.wireFormat
+	}
+}
+
+extension Date {
+	///Self, pre-rounded to what the wire format can represent, so that a wire
+	///round trip reproduces it exactly (see the note on `Date: LinearEncodable`)
+	public var wireNormalized: Date {
+		.init(timeIntervalSince1970: timeIntervalSince1970)
 	}
 }
 

--- a/Sources/CommProtocol/Objects/Dates.swift
+++ b/Sources/CommProtocol/Objects/Dates.swift
@@ -9,36 +9,44 @@ import Foundation
 
 //two different formats for dates
 
-///The wire format stores `timeIntervalSince1970.bitPattern`, but `Date` equates on
-///`timeIntervalSinceReferenceDate`, and converting between the two epochs in Double
-///can round away low mantissa bits (it does for about half of current-era clock
-///values). So for an arbitrary in-memory Date (e.g. `.now`),
-///`parse(wireFormat) == original` is a coin flip — never compare un-normalized
-///Dates (or structs containing them) bit-exactly across a wire round trip.
+///`Date` deliberately does not conform to LinearEncodable — wire structs carry
+///`WireDate` (or the hour-quantized `RoundedDate`) instead, so a raw `Date`
+///wire field is a compile error.
 ///
-///For the timestamps this library stamps, one round trip is a fixed point: the
-///parsed Date re-encodes to identical bytes and stays `==` through further round
-///trips. `wireNormalized` applies that rounding up front — identical wire bytes,
-///moving the instant by at most 2⁻²³ s (~120 ns for current-era dates) — so a
-///Date stamped `.now.wireNormalized` round-trips to exact equality. Library
-///constructors stamp their wire-bound Dates this way (`NewAgentData`'s init
-///normalizes its caller-supplied expiration); normalize likewise if you feed a
-///Date-typed wire field directly. `RoundedDate` fields, like the
-///Resource/ProtocolAddress expirations, quantize to whole hours instead —
-///`wireNormalized` is inert there.
+///The wire format stores `timeIntervalSince1970.bitPattern`, but `Date` equates
+///on `timeIntervalSinceReferenceDate`, and converting between the two epochs in
+///Double can round away low mantissa bits (it does for about half of
+///current-era clock values) — so a raw Date would survive a wire round trip
+///`==`-intact only by coin flip. `WireDate` pre-rounds the instant to the wire
+///grid at construction (moving it by at most 2⁻²³ s, ~120 ns for current-era
+///dates), which makes round trips exact by construction. DateEncodingTests
+///sweeps these properties across the distinct float-grid regimes.
 ///
-///Caveats at the edges: bytes from a foreign encoder can need a second parse to
-///reach the fixed point, `parse` does no finiteness check (NaN/±inf bit patterns
-///parse into Dates that poison comparisons), and Dates within 2⁻²⁴ s of the
-///reference epoch collapse onto it. DateEncodingTests sweeps these properties
-///across the distinct float-grid regimes.
-extension Date: LinearEncodable {
-	public static func parse(_ input: Data) throws -> (Date, Int) {
+///Caveats at the edges: parse does no finiteness check (NaN/±inf bit patterns
+///parse into Dates that poison comparisons); bytes from a foreign encoder may
+///re-encode differently (parsed values are stable from then on); Dates within
+///2⁻²⁴ s of the reference epoch collapse onto it when normalized.
+public struct WireDate: Equatable, Sendable {
+	///Pre-rounded to the wire grid at construction; wire round trips
+	///reproduce finite dates exactly
+	public let date: Date
+
+	public init(date: Date) {
+		self.date = date.wireNormalized
+	}
+
+	public static var now: WireDate { .init(date: .now) }
+}
+
+extension WireDate: LinearEncodable {
+	public static func parse(_ input: Data) throws -> (WireDate, Int) {
 		let (bitPattern, consumed) = try UInt64.parse(input)
 		return (
 			.init(
-				timeIntervalSince1970: .init(
-					bitPattern: bitPattern
+				date: .init(
+					timeIntervalSince1970: .init(
+						bitPattern: bitPattern
+					)
 				)
 			),
 			consumed
@@ -46,14 +54,13 @@ extension Date: LinearEncodable {
 	}
 
 	public var wireFormat: Data {
-		timeIntervalSince1970.bitPattern.wireFormat
+		date.timeIntervalSince1970.bitPattern.wireFormat
 	}
 }
 
 extension Date {
-	///Self, pre-rounded to what the wire format can represent, so that a wire
-	///round trip reproduces a finite Date exactly (see the note on
-	///`Date: LinearEncodable`)
+	///Self, pre-rounded to what the wire format can represent — the rounding
+	///`WireDate` applies at construction
 	public var wireNormalized: Date {
 		.init(timeIntervalSince1970: timeIntervalSince1970)
 	}

--- a/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
+++ b/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
@@ -19,14 +19,37 @@ import Foundation
 ///Both fields ride INSIDE the signed welcome body, binding the deferred PQ key
 ///material to the sender's identity root: a post-establishment channel
 ///compromise cannot substitute the PQ key package at A.4.
+///
+///The commitment is pinned to `.sha256` in both inits: the session layer
+///accepts exactly SHA-256/32, so any other digest type is a wire-contract
+///violation HERE — an immediate, local decode error — not a deep opaque
+///failure at the A.4 side-band after establishment already succeeded.
 public struct PQEstablishmentKeyMaterial: Equatable, Sendable {
 	public let keyPackageData: Data
 	public let bootstrapKpCommitment: TypedDigest
 
+	///`bootstrapKpCommitment` takes the raw 32 digest bytes the session layer
+	///hands out (and expects back); the `.sha256` wrapper — the only
+	///commitment the A.4 verifier accepts — is applied here, so an illegal
+	///create is unrepresentable rather than guarded downstream.
 	public init(
 		keyPackageData: Data,
-		bootstrapKpCommitment: TypedDigest
-	) {
+		bootstrapKpCommitment: Data
+	) throws {
+		//an empty key package would encode as the OptionalData none-marker and
+		//fail the RECIPIENT's parse — reject it locally, before the welcome is
+		//signed and sent
+		guard !keyPackageData.isEmpty else {
+			throw LinearEncodingError.requiredValueMissing
+		}
+		self.keyPackageData = keyPackageData
+		self.bootstrapKpCommitment = try TypedDigest(
+			prefix: .sha256,
+			checkedData: bootstrapKpCommitment
+		)
+	}
+
+	init(keyPackageData: Data, bootstrapKpCommitment: TypedDigest) {
 		self.keyPackageData = keyPackageData
 		self.bootstrapKpCommitment = bootstrapKpCommitment
 	}
@@ -37,6 +60,14 @@ extension PQEstablishmentKeyMaterial: LinearEncodedPair {
 	public var second: TypedDigest { bootstrapKpCommitment }
 
 	public init(first: Data, second: TypedDigest) throws {
+		//pin the commitment's digest type on the wire: today .sha256 is the
+		//only DigestTypes case, so this cannot fire — it exists for the day
+		//the enum grows for some unrelated feature, keeping a non-SHA-256
+		//commitment a decode error here rather than a signed, established
+		//welcome that strands at A.4
+		guard second.type == .sha256 else {
+			throw LinearEncodingError.invalidPrefix
+		}
 		self.init(
 			keyPackageData: first,
 			bootstrapKpCommitment: second

--- a/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
+++ b/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
@@ -1,0 +1,45 @@
+//
+//  PQEstablishmentKeyMaterial.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import Foundation
+
+///The establishment key material a PQ (TwoMLSPQ v20) welcome carries, kept
+///atomic so the commitment can never be separated from the key package it
+///travels with:
+/// - `keyPackageData`: the replier's CLASSICAL return key package (a bare MLS
+///   KeyPackage message — the PQ half no longer rides the establishment reply)
+/// - `bootstrapKpCommitment`: SHA-256 over the replier's pre-committed A.4
+///   bootstrap PQ key package. The PQ key package itself follows in the A.4
+///   side-band; the session layer rejects one that does not hash to this value.
+///
+///Both fields ride INSIDE the signed welcome body, binding the deferred PQ key
+///material to the sender's identity root: a post-establishment channel
+///compromise cannot substitute the PQ key package at A.4.
+public struct PQEstablishmentKeyMaterial: Equatable, Sendable {
+	public let keyPackageData: Data
+	public let bootstrapKpCommitment: TypedDigest
+
+	public init(
+		keyPackageData: Data,
+		bootstrapKpCommitment: TypedDigest
+	) {
+		self.keyPackageData = keyPackageData
+		self.bootstrapKpCommitment = bootstrapKpCommitment
+	}
+}
+
+extension PQEstablishmentKeyMaterial: LinearEncodedPair {
+	public var first: Data { keyPackageData }
+	public var second: TypedDigest { bootstrapKpCommitment }
+
+	public init(first: Data, second: TypedDigest) throws {
+		self.init(
+			keyPackageData: first,
+			bootstrapKpCommitment: second
+		)
+	}
+}

--- a/Sources/CommProtocol/V1Formats/AgentHelloReply.swift
+++ b/Sources/CommProtocol/V1Formats/AgentHelloReply.swift
@@ -27,7 +27,7 @@ public struct AgentHelloReply: Sendable {
 		public let groupIdSeed: DataIdentifier
 		public let agentSignatureWelcome: TypedSignature
 		public let seqNo: UInt32  //sets the initial seqNo
-		public let sentTime: Date  //just as messages assert local send time
+		public let sentTime: WireDate  //just as messages assert local send time
 	}
 }
 
@@ -49,13 +49,13 @@ extension AgentHelloReply.Content: LinearEncodedQuad {
 	public var first: DataIdentifier { groupIdSeed }
 	public var second: TypedSignature { agentSignatureWelcome }
 	public var third: UInt32 { seqNo }
-	public var fourth: Date { sentTime }
+	public var fourth: WireDate { sentTime }
 
 	public init(
 		first: DataIdentifier,
 		second: TypedSignature,
 		third: UInt32,
-		fourth: Date
+		fourth: WireDate
 	) throws {
 		self.init(
 			groupIdSeed: first,

--- a/Sources/CommProtocolMocks/Mocks.swift
+++ b/Sources/CommProtocolMocks/Mocks.swift
@@ -65,6 +65,17 @@ extension TypedDigest {
 	}
 }
 
+//consumed by both welcome arms (PQAnchorWelcome + PQAppWelcome tests), so it
+//lives here rather than in either arm's Type+Mock file
+extension PQEstablishmentKeyMaterial {
+	public static func mock() throws -> Self {
+		try .init(
+			keyPackageData: Mocks.mockMessage(),
+			bootstrapKpCommitment: TypedDigest.mock().digest
+		)
+	}
+}
+
 extension DescribedImage {
 	public static func mock() throws -> Self {
 		.init(

--- a/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
+++ b/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
@@ -1,0 +1,53 @@
+//
+//  PQAppWelcome+Mock.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import CommProtocol
+import CryptoKit
+import Foundation
+
+extension PQAppWelcome {
+	static public func mock(
+		remoteAgentKey: AgentPublicKey,
+		keyMaterial: PQEstablishmentKeyMaterial
+	) throws -> PQAppWelcome {
+		let (identityKey, signedIdentity) =
+			try Mocks
+			.mockIdentity()
+
+		let groupId = DataIdentifier(width: .bits256)
+
+		let (agentKey, introduction) =
+			try identityKey
+			.createNewDelegate(
+				signedIdentity: signedIdentity,
+				identityMutable: .mock(),
+				agentType: .welcome(
+					remoteAgentId: remoteAgentKey,
+					groupId: groupId
+				)
+			)
+
+		return try agentKey.createPQAppWelcome(
+			introduction: introduction,
+			agentData: .mock(),
+			groupId: groupId,
+			keyMaterial: keyMaterial
+		)
+	}
+}
+
+extension PQEstablishmentKeyMaterial {
+	static public func mock() -> PQEstablishmentKeyMaterial {
+		.init(
+			keyPackageData: SymmetricKey(size: .bits256).rawRepresentation,
+			bootstrapKpCommitment: .init(
+				prefix: .sha256,
+				over: SymmetricKey(size: .bits256).rawRepresentation
+			)
+		)
+	}
+}

--- a/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
+++ b/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
@@ -6,7 +6,6 @@
 //
 
 import CommProtocol
-import CryptoKit
 import Foundation
 
 extension PQAppWelcome {
@@ -36,18 +35,6 @@ extension PQAppWelcome {
 			agentData: .mock(),
 			groupId: groupId,
 			keyMaterial: keyMaterial
-		)
-	}
-}
-
-extension PQEstablishmentKeyMaterial {
-	static public func mock() -> PQEstablishmentKeyMaterial {
-		.init(
-			keyPackageData: SymmetricKey(size: .bits256).rawRepresentation,
-			bootstrapKpCommitment: .init(
-				prefix: .sha256,
-				over: SymmetricKey(size: .bits256).rawRepresentation
-			)
 		)
 	}
 }

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -57,7 +57,7 @@ struct PQAnchorWelcomeTests {
 		#expect(verifiedReply.agent.agentKey == blairReplyAgent.publicKey)
 		//pin every Verified field against the created content (Data fields are
 		//interchangeable by type — a wrong-field regression would type-check);
-		//sentTime equality holds because create stamps it `.now.wireNormalized`
+		//sentTime equality holds because it is a WireDate, exact across round trips
 		#expect(verifiedReply.welcome.keyMaterial == keyMaterial)
 		#expect(verifiedReply.mlsWelcomeData == content.mlsWelcomeData)
 		#expect(verifiedReply.welcome.seqNo == content.welcome.seqNo)

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -56,12 +56,13 @@ struct PQAnchorWelcomeTests {
 			)
 		#expect(verifiedReply.agent.agentKey == blairReplyAgent.publicKey)
 		//pin every Verified field against the created content (Data fields are
-		//interchangeable by type — a wrong-field regression would type-check),
-		//except sentTime, whose epoch conversion does not round-trip bit-exactly
+		//interchangeable by type — a wrong-field regression would type-check);
+		//sentTime equality holds because create stamps it `.now.wireNormalized`
 		#expect(verifiedReply.welcome.keyMaterial == keyMaterial)
 		#expect(verifiedReply.mlsWelcomeData == content.mlsWelcomeData)
 		#expect(verifiedReply.welcome.seqNo == content.welcome.seqNo)
 		#expect(verifiedReply.welcome.agentUpdate == content.welcome.agentUpdate)
+		#expect(verifiedReply.welcome.sentTime == content.welcome.sentTime)
 	}
 
 	@Test func testWrongRecipientFailsVerification() throws {

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -1,0 +1,118 @@
+//
+//  PQAnchorWelcomeTests.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import AtprotoTypes
+import AtprotoTypesMocks
+import CommProtocol
+import CommProtocolMocks
+import CryptoKit
+import Foundation
+import Testing
+
+struct PQAnchorWelcomeTests {
+	let alexDID = Atproto.DID.mock()
+	let alexPrivateAnchor: PrivateActiveAnchor
+	let blairDID = Atproto.DID.mock()
+	let blairPrivateAnchor: PrivateActiveAnchor
+
+	init() throws {
+		alexPrivateAnchor = .create(for: alexDID)
+		blairPrivateAnchor = .create(for: blairDID)
+	}
+
+	private func makeReply(
+		keyMaterial: PQEstablishmentKeyMaterial,
+		recipient: PublicAnchor
+	) throws -> (PrivateAnchorAgent, PQAnchorWelcome, PQAnchorWelcome.Content) {
+		try blairPrivateAnchor.createPQAnchorWelcome(
+			agentUpdate: .mock(),
+			keyMaterial: keyMaterial,
+			mlsWelcomeMessage: SymmetricKey(size: .bits256).rawRepresentation,
+			newAgentKey: AgentPrivateKey(),
+			recipient: recipient,
+			newSeqNo: .random(in: .min...(.max))
+		)
+	}
+
+	@Test func testPQAnchorExchange() throws {
+		let keyMaterial = PQEstablishmentKeyMaterial.mock()
+		let (blairReplyAgent, reply, _) = try makeReply(
+			keyMaterial: keyMaterial,
+			recipient: alexPrivateAnchor.publicAnchor
+		)
+
+		//wire round-trip before verification, as the recipient sees it
+		let received = try PQAnchorWelcome.finalParse(reply.wireFormat)
+
+		let verifiedReply = try blairPrivateAnchor.publicKey
+			.verify(
+				pqReply: received,
+				recipient: alexPrivateAnchor.publicAnchor,
+			)
+		#expect(verifiedReply.agent.agentKey == blairReplyAgent.publicKey)
+		//the establishment key material survives the round trip intact
+		#expect(verifiedReply.welcome.keyMaterial == keyMaterial)
+		#expect(
+			verifiedReply.welcome.keyMaterial.bootstrapKpCommitment.digest.count == 32
+		)
+	}
+
+	@Test func testWrongRecipientFailsVerification() throws {
+		let (_, reply, _) = try makeReply(
+			keyMaterial: .mock(),
+			recipient: alexPrivateAnchor.publicAnchor
+		)
+
+		//recipient binding: a welcome addressed to Alex must not verify for Casey
+		let caseyPrivateAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+		#expect(throws: (any Error).self) {
+			_ = try blairPrivateAnchor.publicKey.verify(
+				pqReply: reply,
+				recipient: caseyPrivateAnchor.publicAnchor
+			)
+		}
+	}
+
+	@Test func testTamperedPackageFailsVerification() throws {
+		let (_, reply, _) = try makeReply(
+			keyMaterial: .mock(),
+			recipient: alexPrivateAnchor.publicAnchor
+		)
+
+		//flip one byte of the signed package: the anchor signature must fail
+		var tampered = reply.second
+		tampered[tampered.count / 2] ^= 0x01
+		let forged = PQAnchorWelcome(first: reply.first, second: tampered)
+		#expect(throws: (any Error).self) {
+			_ = try blairPrivateAnchor.publicKey.verify(
+				pqReply: forged,
+				recipient: alexPrivateAnchor.publicAnchor
+			)
+		}
+	}
+
+	@Test func testClassicalWelcomeIsNotAPQWelcome() throws {
+		//domain separation: a classical AnchorWelcome's bytes must never
+		//survive the PQ parse+verify chain (distinct layout AND distinct
+		//signature discriminators — either alone must kill it)
+		let (_, classicalReply, _) = try blairPrivateAnchor.createAnchorWelcome(
+			agentUpdate: .mock(),
+			keyPackageData: SymmetricKey(size: .bits256).rawRepresentation,
+			mlsWelcomeMessage: SymmetricKey(size: .bits256).rawRepresentation,
+			newAgentKey: AgentPrivateKey(),
+			recipient: alexPrivateAnchor.publicAnchor,
+			newSeqNo: .random(in: .min...(.max))
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try blairPrivateAnchor.publicKey.verify(
+				pqReply: try PQAnchorWelcome.finalParse(classicalReply.wireFormat),
+				recipient: alexPrivateAnchor.publicAnchor
+			)
+		}
+	}
+}

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -7,11 +7,12 @@
 
 import AtprotoTypes
 import AtprotoTypesMocks
-import CommProtocol
 import CommProtocolMocks
 import CryptoKit
 import Foundation
 import Testing
+
+@testable import CommProtocol
 
 struct PQAnchorWelcomeTests {
 	let alexDID = Atproto.DID.mock()
@@ -39,8 +40,8 @@ struct PQAnchorWelcomeTests {
 	}
 
 	@Test func testPQAnchorExchange() throws {
-		let keyMaterial = PQEstablishmentKeyMaterial.mock()
-		let (blairReplyAgent, reply, _) = try makeReply(
+		let keyMaterial = try PQEstablishmentKeyMaterial.mock()
+		let (blairReplyAgent, reply, content) = try makeReply(
 			keyMaterial: keyMaterial,
 			recipient: alexPrivateAnchor.publicAnchor
 		)
@@ -54,16 +55,18 @@ struct PQAnchorWelcomeTests {
 				recipient: alexPrivateAnchor.publicAnchor,
 			)
 		#expect(verifiedReply.agent.agentKey == blairReplyAgent.publicKey)
-		//the establishment key material survives the round trip intact
+		//pin every Verified field against the created content (Data fields are
+		//interchangeable by type — a wrong-field regression would type-check),
+		//except sentTime, whose epoch conversion does not round-trip bit-exactly
 		#expect(verifiedReply.welcome.keyMaterial == keyMaterial)
-		#expect(
-			verifiedReply.welcome.keyMaterial.bootstrapKpCommitment.digest.count == 32
-		)
+		#expect(verifiedReply.mlsWelcomeData == content.mlsWelcomeData)
+		#expect(verifiedReply.welcome.seqNo == content.welcome.seqNo)
+		#expect(verifiedReply.welcome.agentUpdate == content.welcome.agentUpdate)
 	}
 
 	@Test func testWrongRecipientFailsVerification() throws {
 		let (_, reply, _) = try makeReply(
-			keyMaterial: .mock(),
+			keyMaterial: try .mock(),
 			recipient: alexPrivateAnchor.publicAnchor
 		)
 
@@ -79,7 +82,7 @@ struct PQAnchorWelcomeTests {
 
 	@Test func testTamperedPackageFailsVerification() throws {
 		let (_, reply, _) = try makeReply(
-			keyMaterial: .mock(),
+			keyMaterial: try .mock(),
 			recipient: alexPrivateAnchor.publicAnchor
 		)
 
@@ -96,9 +99,12 @@ struct PQAnchorWelcomeTests {
 	}
 
 	@Test func testClassicalWelcomeIsNotAPQWelcome() throws {
-		//domain separation: a classical AnchorWelcome's bytes must never
-		//survive the PQ parse+verify chain (distinct layout AND distinct
-		//signature discriminators — either alone must kill it)
+		//domain separation, classical→PQ direction. What this proves: the OUTER
+		//signature discriminator ("AnchorReply.*" vs "PQAnchorReply.*") rejects
+		//the classical welcome — the outer shapes are byte-identical, so parse
+		//succeeds, and verifyPackage checks the signature BEFORE parsing the
+		//package, so the Welcome-layout divergence is never reached here (it is
+		//a second, independent defense, not exercised by this test).
 		let (_, classicalReply, _) = try blairPrivateAnchor.createAnchorWelcome(
 			agentUpdate: .mock(),
 			keyPackageData: SymmetricKey(size: .bits256).rawRepresentation,
@@ -108,10 +114,129 @@ struct PQAnchorWelcomeTests {
 			newSeqNo: .random(in: .min...(.max))
 		)
 
-		#expect(throws: (any Error).self) {
+		let parsed = try PQAnchorWelcome.finalParse(classicalReply.wireFormat)
+		//ProtocolError (verification), not LinearEncodingError (parse)
+		#expect(throws: ProtocolError.self) {
 			_ = try blairPrivateAnchor.publicKey.verify(
-				pqReply: try PQAnchorWelcome.finalParse(classicalReply.wireFormat),
+				pqReply: parsed,
 				recipient: alexPrivateAnchor.publicAnchor
+			)
+		}
+	}
+
+	@Test func testPQWelcomeIsNotAClassicalWelcome() throws {
+		//domain separation, the reverse (PQ→classical) direction: a PQ welcome's
+		//bytes must not verify on the classical route either (cross-route
+		//replay/downgrade). Same mechanism — the classical verify reconstructs
+		//its own discriminator, so the PQ outer signature never matches.
+		let (_, pqReply, _) = try makeReply(
+			keyMaterial: try .mock(),
+			recipient: alexPrivateAnchor.publicAnchor
+		)
+
+		let parsed = try AnchorWelcome.finalParse(pqReply.wireFormat)
+		//ProtocolError (verification), not LinearEncodingError (parse)
+		#expect(throws: ProtocolError.self) {
+			_ = try blairPrivateAnchor.publicKey.verify(
+				reply: parsed,
+				recipient: alexPrivateAnchor.publicAnchor
+			)
+		}
+	}
+
+	@Test func testForgedAgentSignatureFailsVerification() throws {
+		//the INNER guard: an agent signature minted by a key the content does
+		//not name must fail even when the outer anchor signature is genuine.
+		//(The tamper test above breaks the OUTER signature, which throws before
+		//the inner guard is reached — this is the only test that exercises it.)
+		let (_, _, content) = try makeReply(
+			keyMaterial: try .mock(),
+			recipient: alexPrivateAnchor.publicAnchor
+		)
+
+		let mallory = AgentPrivateKey()
+		let forgedPackage = PQAnchorWelcome.Package(
+			first: content,
+			second: try mallory.signer(
+				content
+					.agentSignatureBody(
+						recipient: alexPrivateAnchor.publicAnchor
+					)
+					.wireFormat
+			)
+		)
+		//outer anchor signature over the forged package, correctly minted
+		let outerSignature = try blairPrivateAnchor.privateKey.signer(
+			try PQAnchorWelcome.AnchorSignatureBody(
+				encodedPackage: try forgedPackage.wireFormat,
+				knownAnchor: blairPrivateAnchor.publicKey,
+				recipient: alexPrivateAnchor.publicAnchor,
+			).wireFormat
+		)
+		let forged = PQAnchorWelcome(
+			first: outerSignature,
+			second: try forgedPackage.wireFormat
+		)
+
+		//ProtocolError (verification), not LinearEncodingError (parse)
+		#expect(throws: ProtocolError.self) {
+			_ = try blairPrivateAnchor.publicKey.verify(
+				pqReply: forged,
+				recipient: alexPrivateAnchor.publicAnchor
+			)
+		}
+	}
+}
+
+struct PQEstablishmentKeyMaterialWireTests {
+	//The commitment's wire contract: prefix byte 0x01 (sha256) + exactly 32
+	//bytes, frozen independent of how DigestTypes evolves. Today the 0x02 case
+	//is rejected by TypedDigest's own unknown-prefix parse; once DigestTypes
+	//grows a second case for any unrelated feature, the .sha256 pin in
+	//PQEstablishmentKeyMaterial's parse init is what keeps this red — the
+	//session layer accepts exactly SHA-256/32, so any other digest must die
+	//at decode, not deep in the A.4 side-band.
+	private func encoded(prefix: UInt8, digestBytes: Int) throws -> Data {
+		let kp = SymmetricKey(size: .bits256).rawRepresentation
+		var bytes = Data()
+		bytes.append(UInt8(kp.count))  //OptionalData short-form length prefix
+		bytes.append(kp)
+		bytes.append(prefix)
+		bytes.append(SymmetricKey(size: .bits256).rawRepresentation.prefix(digestBytes))
+		return bytes
+	}
+
+	@Test func testRoundTrip() throws {
+		let material = try PQEstablishmentKeyMaterial.mock()
+		let received = try PQEstablishmentKeyMaterial.finalParse(material.wireFormat)
+		#expect(received == material)
+	}
+
+	@Test func testUnknownDigestPrefixFailsParse() throws {
+		#expect(throws: (any Error).self) {
+			_ = try PQEstablishmentKeyMaterial.finalParse(
+				try encoded(prefix: 0x02, digestBytes: 32)
+			)
+		}
+	}
+
+	@Test func testTruncatedDigestFailsParse() throws {
+		#expect(throws: (any Error).self) {
+			_ = try PQEstablishmentKeyMaterial.finalParse(
+				try encoded(prefix: 0x01, digestBytes: 31)
+			)
+		}
+	}
+
+	@Test func testEmptyKeyPackageIsRejectedAtCreate() throws {
+		//an empty key package encodes as the OptionalData none-marker ([0]),
+		//which the RECIPIENT's parse rejects as requiredValueMissing — the
+		//create-side guard converts that remote parse failure into a local,
+		//immediate error before the welcome ever goes out
+		#expect(throws: (any Error).self) {
+			_ = try PQEstablishmentKeyMaterial(
+				keyPackageData: Data(),
+				bootstrapKpCommitment: try TypedDigest.mock().digest
 			)
 		}
 	}

--- a/Tests/CommProtocolTests/DateEncodingTests.swift
+++ b/Tests/CommProtocolTests/DateEncodingTests.swift
@@ -9,48 +9,82 @@ import CommProtocol
 import Foundation
 import Testing
 
-///Sweeps the properties documented on `Date: LinearEncodable`: the epoch
-///conversion in the wire format rounds away sub-µs precision for about half
-///of arbitrary clock values, but parsing is a fixed point, and a
-///`wireNormalized` Date round-trips to exact equality with identical bytes.
+///Sweeps the properties documented on `Date: LinearEncodable` across the
+///distinct float-grid regimes: whether a raw Date survives the epoch
+///conversion depends on the relative ulp of timeIntervalSinceReferenceDate
+///vs timeIntervalSince1970 at that magnitude, so each regime gets a sweep.
 struct DateEncodingTests {
-	//deterministic sweep: base is mid-2026 in the reference epoch, stepped by
-	//2^-23 s (~one ulp at this magnitude) to exercise the low mantissa bits
-	//the 1970-epoch conversion rounds away
-	static let sweep: [Date] = (0..<10_000).map {
-		Date(timeIntervalSinceReferenceDate: 806_000_000.0 + Double($0) * 0x1p-23)
+	///(base seconds since the reference epoch, whether raw Dates at that
+	///magnitude round-trip exactly — true iff the 1970-epoch grid is at
+	///least as fine as the reference-epoch grid there)
+	static let regimes: [(base: Double, rawRoundTripExact: Bool)] = [
+		(1.0, false),  //at the 2001 epoch: 1970 grid vastly coarser
+		(-800_000_000.0, true),  //~1975: 1970 grid finer
+		(806_000_000.0, false),  //~2026: 1970 grid one binade coarser
+		(1_100_000_000.0, true),  //~2035–2069: grids coincide
+		(2_200_000_000.0, true),  //~2070+: grids coincide
+	]
+
+	//stepped by the base's own ulp to exercise the low mantissa bits the
+	//epoch conversion can round away
+	static func sweep(from base: Double) -> [Date] {
+		(0..<64).map {
+			Date(timeIntervalSinceReferenceDate: base + Double($0) * base.ulp)
+		}
 	}
 
 	@Test func normalizedDatesRoundTripExactly() throws {
-		for date in Self.sweep {
-			let normalized = date.wireNormalized
-			#expect(normalized.wireFormat == date.wireFormat)
-			let (parsed, consumed) = try Date.parse(normalized.wireFormat)
-			#expect(consumed == normalized.wireFormat.count)
-			#expect(parsed == normalized)
+		for regime in Self.regimes {
+			for (step, date) in Self.sweep(from: regime.base).enumerated() {
+				let normalized = date.wireNormalized
+				#expect(
+					normalized.wireFormat == date.wireFormat,
+					"base \(regime.base), step \(step)"
+				)
+				let parsed = try Date.finalParse(normalized.wireFormat)
+				#expect(parsed == normalized, "base \(regime.base), step \(step)")
+			}
 		}
 	}
 
 	@Test func parseIsAFixedPoint() throws {
-		for date in Self.sweep {
-			let (once, _) = try Date.parse(date.wireFormat)
-			#expect(once.wireFormat == date.wireFormat)
-			let (twice, _) = try Date.parse(once.wireFormat)
-			#expect(twice == once)
+		for regime in Self.regimes {
+			for (step, date) in Self.sweep(from: regime.base).enumerated() {
+				let once = try Date.finalParse(date.wireFormat)
+				#expect(
+					once.wireFormat == date.wireFormat,
+					"base \(regime.base), step \(step)"
+				)
+				let twice = try Date.finalParse(once.wireFormat)
+				#expect(twice == once, "base \(regime.base), step \(step)")
+			}
 		}
 	}
 
-	@Test func rawDatesDoNotReliablyRoundTrip() throws {
-		//canary for why wireNormalized exists: ~50% of the sweep fails
-		//bit-exact equality after one round trip. If this ever reports zero
-		//failures, Date's storage or the wire format changed and
-		//wireNormalized can be retired.
-		var failures = 0
-		for date in Self.sweep {
-			if try Date.parse(date.wireFormat).0 != date {
-				failures += 1
+	@Test func rawRoundTripExactnessTracksTheGridRegime() throws {
+		//canary for why wireNormalized exists: raw Dates fail bit-exact
+		//equality after a round trip wherever the 1970 grid is coarser
+		//(half the steps in 2026, nearly all of them at the 2001 epoch),
+		//and survive wherever it isn't. If a coarser-grid regime ever
+		//reports zero failures, Date's storage or the wire format changed
+		//and wireNormalized can be retired; zero failures in the other
+		//regimes is expected grid coincidence, not a fix.
+		for regime in Self.regimes {
+			let failures = try Self.sweep(from: regime.base).count {
+				try Date.finalParse($0.wireFormat) != $0
+			}
+			if regime.rawRoundTripExact {
+				#expect(failures == 0, "base \(regime.base)")
+			} else {
+				#expect(failures > 0, "base \(regime.base)")
 			}
 		}
-		#expect(failures > 0)
+	}
+
+	//the live-clock spot check formerly in ResourceTests, tightened to the
+	//exact contract: normalize, then equality is bit-exact
+	@Test func liveClockNormalizedRoundTrip() throws {
+		let stamped = Date.now.wireNormalized
+		#expect(try Date.finalParse(stamped.wireFormat) == stamped)
 	}
 }

--- a/Tests/CommProtocolTests/DateEncodingTests.swift
+++ b/Tests/CommProtocolTests/DateEncodingTests.swift
@@ -9,15 +9,16 @@ import CommProtocol
 import Foundation
 import Testing
 
-///Sweeps the properties documented on `Date: LinearEncodable` across the
-///distinct float-grid regimes: whether a raw Date survives the epoch
-///conversion depends on the relative ulp of timeIntervalSinceReferenceDate
-///vs timeIntervalSince1970 at that magnitude, so each regime gets a sweep.
+///Sweeps the properties documented on `WireDate` across the distinct
+///float-grid regimes: whether the epoch conversion in the wire format
+///moves a raw Date depends on the relative ulp of
+///timeIntervalSinceReferenceDate vs timeIntervalSince1970 at that
+///magnitude, so each regime gets a sweep.
 struct DateEncodingTests {
-	///(base seconds since the reference epoch, whether raw Dates at that
-	///magnitude round-trip exactly — true iff the 1970-epoch grid is at
-	///least as fine as the reference-epoch grid there)
-	static let regimes: [(base: Double, rawRoundTripExact: Bool)] = [
+	///(base seconds since the reference epoch, whether the epoch
+	///conversion is exact there — true iff the 1970-epoch grid is at
+	///least as fine as the reference-epoch grid)
+	static let regimes: [(base: Double, epochConversionExact: Bool)] = [
 		(1.0, false),  //at the 2001 epoch: 1970 grid vastly coarser
 		(-800_000_000.0, true),  //~1975: 1970 grid finer
 		(806_000_000.0, false),  //~2026: 1970 grid one binade coarser
@@ -33,58 +34,45 @@ struct DateEncodingTests {
 		}
 	}
 
-	@Test func normalizedDatesRoundTripExactly() throws {
+	@Test func wireDatesRoundTripExactly() throws {
 		for regime in Self.regimes {
 			for (step, date) in Self.sweep(from: regime.base).enumerated() {
-				let normalized = date.wireNormalized
+				let wireDate = WireDate(date: date)
+				let once = try WireDate.finalParse(wireDate.wireFormat)
+				#expect(once == wireDate, "base \(regime.base), step \(step)")
 				#expect(
-					normalized.wireFormat == date.wireFormat,
+					once.wireFormat == wireDate.wireFormat,
 					"base \(regime.base), step \(step)"
 				)
-				let parsed = try Date.finalParse(normalized.wireFormat)
-				#expect(parsed == normalized, "base \(regime.base), step \(step)")
-			}
-		}
-	}
-
-	@Test func parseIsAFixedPoint() throws {
-		for regime in Self.regimes {
-			for (step, date) in Self.sweep(from: regime.base).enumerated() {
-				let once = try Date.finalParse(date.wireFormat)
-				#expect(
-					once.wireFormat == date.wireFormat,
-					"base \(regime.base), step \(step)"
-				)
-				let twice = try Date.finalParse(once.wireFormat)
+				let twice = try WireDate.finalParse(once.wireFormat)
 				#expect(twice == once, "base \(regime.base), step \(step)")
 			}
 		}
 	}
 
-	@Test func rawRoundTripExactnessTracksTheGridRegime() throws {
-		//canary for why wireNormalized exists: raw Dates fail bit-exact
-		//equality after a round trip wherever the 1970 grid is coarser
+	@Test func normalizationTracksTheGridRegime() throws {
+		//canary for why WireDate normalizes at construction: the epoch
+		//conversion moves raw Dates wherever the 1970 grid is coarser
 		//(half the steps in 2026, nearly all of them at the 2001 epoch),
-		//and survive wherever it isn't. If a coarser-grid regime ever
-		//reports zero failures, Date's storage or the wire format changed
-		//and wireNormalized can be retired; zero failures in the other
+		//and is exact wherever it isn't. If a coarser-grid regime ever
+		//reports zero moved, Date's storage or the wire format changed
+		//and the normalization can be retired; zero moved in the other
 		//regimes is expected grid coincidence, not a fix.
 		for regime in Self.regimes {
-			let failures = try Self.sweep(from: regime.base).count {
-				try Date.finalParse($0.wireFormat) != $0
+			let moved = Self.sweep(from: regime.base).count {
+				WireDate(date: $0).date != $0
 			}
-			if regime.rawRoundTripExact {
-				#expect(failures == 0, "base \(regime.base)")
+			if regime.epochConversionExact {
+				#expect(moved == 0, "base \(regime.base)")
 			} else {
-				#expect(failures > 0, "base \(regime.base)")
+				#expect(moved > 0, "base \(regime.base)")
 			}
 		}
 	}
 
-	//the live-clock spot check formerly in ResourceTests, tightened to the
-	//exact contract: normalize, then equality is bit-exact
-	@Test func liveClockNormalizedRoundTrip() throws {
-		let stamped = Date.now.wireNormalized
-		#expect(try Date.finalParse(stamped.wireFormat) == stamped)
+	//live-clock spot check on the exact contract
+	@Test func liveClockRoundTrip() throws {
+		let stamped = WireDate.now
+		#expect(try WireDate.finalParse(stamped.wireFormat) == stamped)
 	}
 }

--- a/Tests/CommProtocolTests/DateEncodingTests.swift
+++ b/Tests/CommProtocolTests/DateEncodingTests.swift
@@ -1,0 +1,56 @@
+//
+//  DateEncodingTests.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import CommProtocol
+import Foundation
+import Testing
+
+///Sweeps the properties documented on `Date: LinearEncodable`: the epoch
+///conversion in the wire format rounds away sub-µs precision for about half
+///of arbitrary clock values, but parsing is a fixed point, and a
+///`wireNormalized` Date round-trips to exact equality with identical bytes.
+struct DateEncodingTests {
+	//deterministic sweep: base is mid-2026 in the reference epoch, stepped by
+	//2^-23 s (~one ulp at this magnitude) to exercise the low mantissa bits
+	//the 1970-epoch conversion rounds away
+	static let sweep: [Date] = (0..<10_000).map {
+		Date(timeIntervalSinceReferenceDate: 806_000_000.0 + Double($0) * 0x1p-23)
+	}
+
+	@Test func normalizedDatesRoundTripExactly() throws {
+		for date in Self.sweep {
+			let normalized = date.wireNormalized
+			#expect(normalized.wireFormat == date.wireFormat)
+			let (parsed, consumed) = try Date.parse(normalized.wireFormat)
+			#expect(consumed == normalized.wireFormat.count)
+			#expect(parsed == normalized)
+		}
+	}
+
+	@Test func parseIsAFixedPoint() throws {
+		for date in Self.sweep {
+			let (once, _) = try Date.parse(date.wireFormat)
+			#expect(once.wireFormat == date.wireFormat)
+			let (twice, _) = try Date.parse(once.wireFormat)
+			#expect(twice == once)
+		}
+	}
+
+	@Test func rawDatesDoNotReliablyRoundTrip() throws {
+		//canary for why wireNormalized exists: ~50% of the sweep fails
+		//bit-exact equality after one round trip. If this ever reports zero
+		//failures, Date's storage or the wire format changed and
+		//wireNormalized can be retired.
+		var failures = 0
+		for date in Self.sweep {
+			if try Date.parse(date.wireFormat).0 != date {
+				failures += 1
+			}
+		}
+		#expect(failures > 0)
+	}
+}

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
@@ -26,9 +26,10 @@ private struct LegacyMLSIntroduction: LinearEncodedPair {
 private struct LegacyNewAgentData: LinearEncodedTriple {
 	let first: AgentUpdate
 	let second: [LegacyMLSIntroduction]
-	let third: Date
+	//the shipped decoder read a raw Date here; WireDate parses the same bytes
+	let third: WireDate
 
-	init(first: AgentUpdate, second: [LegacyMLSIntroduction], third: Date) throws {
+	init(first: AgentUpdate, second: [LegacyMLSIntroduction], third: WireDate) throws {
 		self.first = first
 		self.second = second
 		self.third = third
@@ -112,7 +113,7 @@ struct AgentHelloDualOfferTests {
 		#expect(decoded.second.first?.second == classicalIntroduction.encodedKeyPackage)
 		//the PQ package survives as opaque bytes an old decoder simply won't interpret
 		#expect(decoded.second.last?.second == pqShimIntroduction.encodedKeyPackage)
-		#expect(decoded.third == expiration)
+		#expect(decoded.third.date == expiration)
 	}
 
 	///Consumers detect the PQ entry by inspecting the key package (here: the suite id it

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
@@ -68,7 +68,7 @@ struct AgentHelloTests {
 		let modifiedTBS = AgentHello.NewAgentData(
 			agentUpdate: modifedData,
 			keyChoices: agentData.keyChoices,
-			expiration: agentData.expiration
+			expiration: agentData.expiration.date
 		)
 
 		let modifiedSignedAgentData = SignedObject<AgentHello.NewAgentData>(

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -38,20 +38,9 @@ struct PQAppWelcomeTests {
 				.content)
 		#expect(
 			validated.introContents == mockWelcome.introduction.signedContents.content)
-		//Field-wise, not whole-struct equality: Date's linear encoding stores
-		//timeIntervalSince1970.bitPattern, but Date equates on
-		//timeIntervalSinceReferenceDate, and the epoch conversion does not
-		//always round-trip bit-exactly in Double — a pre-existing sub-µs wart,
-		//meaningless on the wire, that whole-struct equality would flake on.
-		let original = mockWelcome.signedContent.content
-		#expect(validated.welcomeContent.groupId == original.groupId)
-		#expect(validated.welcomeContent.agentData == original.agentData)
-		#expect(validated.welcomeContent.seqNo == original.seqNo)
-		#expect(
-			abs(
-				validated.welcomeContent.sentTime
-					.timeIntervalSince(original.sentTime)) < 0.001
-		)
+		//whole-struct equality holds across the wire round trip because
+		//createPQAppWelcome stamps sentTime `.now.wireNormalized`
+		#expect(validated.welcomeContent == mockWelcome.signedContent.content)
 		//the establishment key material survives the round trip intact
 		#expect(validated.welcomeContent.keyMaterial == keyMaterial)
 	}

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -1,0 +1,60 @@
+//
+//  PQAppWelcomeTests.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/17/26.
+//
+
+import CommProtocol
+import CommProtocolMocks
+import CryptoKit
+import Foundation
+import Testing
+
+struct PQAppWelcomeTests {
+	@Test func testValidation() throws {
+		let myAgent = AgentPrivateKey()
+		let keyMaterial = PQEstablishmentKeyMaterial.mock()
+
+		let mockWelcome = try PQAppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyMaterial: keyMaterial
+		)
+
+		//wire round-trip via Combined, as the recipient sees it
+		let combined = PQAppWelcome.Combined(
+			appWelcome: mockWelcome,
+			mlsMessageData: SymmetricKey(size: .bits256).rawRepresentation
+		)
+		let received = try PQAppWelcome.Combined.finalParse(combined.wireFormat)
+
+		let validated = try received.appWelcome.validated(
+			myAgent: myAgent.publicKey
+		)
+
+		#expect(
+			validated.coreIdentity
+				== mockWelcome.introduction.signedIdentity
+				.content)
+		#expect(
+			validated.introContents == mockWelcome.introduction.signedContents.content)
+		#expect(validated.welcomeContent == mockWelcome.signedContent.content)
+		//the establishment key material survives the round trip intact
+		#expect(validated.welcomeContent.keyMaterial == keyMaterial)
+	}
+
+	@Test func testClassicalAppWelcomeIsNotAPQAppWelcome() throws {
+		//domain separation: a classical AppWelcome's bytes must never survive
+		//the PQ parse+validate chain
+		let myAgent = AgentPrivateKey()
+		let classicalWelcome = try AppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyPackageData: SymmetricKey(size: .bits256).rawRepresentation
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try PQAppWelcome.finalParse(classicalWelcome.wireFormat)
+				.validated(myAgent: myAgent.publicKey)
+		}
+	}
+}

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -38,7 +38,20 @@ struct PQAppWelcomeTests {
 				.content)
 		#expect(
 			validated.introContents == mockWelcome.introduction.signedContents.content)
-		#expect(validated.welcomeContent == mockWelcome.signedContent.content)
+		//Field-wise, not whole-struct equality: Date's linear encoding stores
+		//timeIntervalSince1970.bitPattern, but Date equates on
+		//timeIntervalSinceReferenceDate, and the epoch conversion does not
+		//always round-trip bit-exactly in Double — a pre-existing sub-µs wart,
+		//meaningless on the wire, that whole-struct equality would flake on.
+		let original = mockWelcome.signedContent.content
+		#expect(validated.welcomeContent.groupId == original.groupId)
+		#expect(validated.welcomeContent.agentData == original.agentData)
+		#expect(validated.welcomeContent.seqNo == original.seqNo)
+		#expect(
+			abs(
+				validated.welcomeContent.sentTime
+					.timeIntervalSince(original.sentTime)) < 0.001
+		)
 		//the establishment key material survives the round trip intact
 		#expect(validated.welcomeContent.keyMaterial == keyMaterial)
 	}

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -14,7 +14,7 @@ import Testing
 struct PQAppWelcomeTests {
 	@Test func testValidation() throws {
 		let myAgent = AgentPrivateKey()
-		let keyMaterial = PQEstablishmentKeyMaterial.mock()
+		let keyMaterial = try PQEstablishmentKeyMaterial.mock()
 
 		let mockWelcome = try PQAppWelcome.mock(
 			remoteAgentKey: myAgent.publicKey,
@@ -58,7 +58,8 @@ struct PQAppWelcomeTests {
 
 	@Test func testClassicalAppWelcomeIsNotAPQAppWelcome() throws {
 		//domain separation: a classical AppWelcome's bytes must never survive
-		//the PQ parse+validate chain
+		//the PQ parse+validate chain (dies at parse — the classical fifth
+		//element's bytes cannot decode as the PQ key-material pair)
 		let myAgent = AgentPrivateKey()
 		let classicalWelcome = try AppWelcome.mock(
 			remoteAgentKey: myAgent.publicKey,
@@ -68,6 +69,75 @@ struct PQAppWelcomeTests {
 		#expect(throws: (any Error).self) {
 			_ = try PQAppWelcome.finalParse(classicalWelcome.wireFormat)
 				.validated(myAgent: myAgent.publicKey)
+		}
+	}
+
+	@Test func testPQAppWelcomeIsNotAClassicalAppWelcome() throws {
+		//the reverse direction: a PQ welcome's bytes must not survive the
+		//CLASSICAL parse+validate chain either (the PQ fifth element leaves
+		//the commitment bytes trailing a classical parse)
+		let myAgent = AgentPrivateKey()
+		let pqWelcome = try PQAppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyMaterial: try .mock()
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try AppWelcome.finalParse(pqWelcome.wireFormat)
+				.validated(myAgent: myAgent.publicKey)
+		}
+	}
+
+	@Test func testTamperedCommitmentFailsValidation() throws {
+		//the PR's core claim, negatively controlled: the bootstrap-KP
+		//commitment rides INSIDE the agent-signed region, so flipping one of
+		//its bytes after signing must fail validation — a post-establishment
+		//channel adversary cannot substitute the PQ key material's binding.
+		let myAgent = AgentPrivateKey()
+		let welcome = try PQAppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyMaterial: try .mock()
+		)
+
+		let original = welcome.signedContent.content
+		var flipped = original.keyMaterial.bootstrapKpCommitment.digest
+		flipped[flipped.startIndex] ^= 0x01
+		let tamperedContent = try PQAppWelcome.Content(
+			first: original.groupId,
+			second: original.agentData,
+			third: original.seqNo,
+			fourth: original.sentTime,
+			fifth: try PQEstablishmentKeyMaterial(
+				keyPackageData: original.keyMaterial.keyPackageData,
+				bootstrapKpCommitment: flipped
+			)
+		)
+		//tampered content, ORIGINAL signature
+		let forged = try PQAppWelcome(
+			first: welcome.introduction,
+			second: try .init(
+				first: tamperedContent,
+				second: welcome.signedContent.second
+			)
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try forged.validated(myAgent: myAgent.publicKey)
+		}
+	}
+
+	@Test func testWrongRecipientAgentFailsValidation() throws {
+		//recipient binding: the welcome names the recipient agent in its
+		//delegation context, so validating as a DIFFERENT agent must throw
+		//(no welcome replay/redirect across the recipient's agents)
+		let myAgent = AgentPrivateKey()
+		let welcome = try PQAppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyMaterial: try .mock()
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try welcome.validated(myAgent: AgentPrivateKey().publicKey)
 		}
 	}
 }

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -39,7 +39,7 @@ struct PQAppWelcomeTests {
 		#expect(
 			validated.introContents == mockWelcome.introduction.signedContents.content)
 		//whole-struct equality holds across the wire round trip because
-		//createPQAppWelcome stamps sentTime `.now.wireNormalized`
+		//sentTime is a WireDate, so whole-struct equality is exact across round trips
 		#expect(validated.welcomeContent == mockWelcome.signedContent.content)
 		//the establishment key material survives the round trip intact
 		#expect(validated.welcomeContent.keyMaterial == keyMaterial)

--- a/Tests/CommProtocolTests/ResourceTests.swift
+++ b/Tests/CommProtocolTests/ResourceTests.swift
@@ -12,17 +12,6 @@ import Testing
 
 struct ResourceTests {
 
-	@Test func testDateLinearEncoding() throws {
-		let date = Date.now
-		let encoded = date.wireFormat
-		print("Encoded date width: \(encoded.count)")
-
-		let decoded = try Date.finalParse(encoded)
-
-		let difference = abs(decoded.timeIntervalSince(date))
-		#expect(difference < 1)
-	}
-
 	@Test func testRoundedDateLinearEncoding() throws {
 		let roundedDate = RoundedDate(date: .now)
 		let encoded = roundedDate.wireFormat


### PR DESCRIPTION
Adds parallel establishment-reply structs for the PQ (TwoMLSPQ v20) path: the reply now carries the replier's **classical-only** return key package plus a `TypedDigest` commitment (SHA-256) to the A.4 bootstrap PQ key package, both inside the signed welcome body so the deferred PQ key material is bound to the sender's identity root. The classical `AnchorWelcome`/`AppWelcome` stay live unchanged — routing discriminates (the PQ reply only ever answers a PQ hello), so per the maintainer ruling there is no version field, just separate structs.

The shared `PQEstablishmentKeyMaterial` pair keeps the commitment atomic with the key package it binds; fresh signature discriminators (`PQAnchorReply.*`) domain-separate the anchor arm, and the card arm's content layout diverges structurally. Tests cover the verify/validate round trips, recipient binding, package tampering, and that a classical welcome's bytes never survive the PQ parse+verify chain (both directions of the app worklist: germDM's PQ reply/receive flows switch to `createPQAnchorWelcome`/`verify(pqReply:)` and `createPQAppWelcome`/`PQAppWelcome.validated`). Suite 71 tests/23 suites green.