### PR TITLE
Domain-separate PQ key material with a reserved 0x00 byte

### DIFF
--- a/.changeset/pq-welcome-discriminator.md
+++ b/.changeset/pq-welcome-discriminator.md
@@ -1,0 +1,17 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Fix a cross-route parsing confusion in the PQ establishment welcomes
+(`PQAppWelcome` / `PQAnchorWelcome`, shipped in 1.6.0). Their domain separation
+from the classical `AppWelcome` / `AnchorWelcome` rested on the signed content's
+fifth element diverging in layout, which in turn depended on the signing-key and
+digest prefix enums keeping disjoint raw values. A crafted 128-byte classical
+key package round-tripped byte-identically through the PQ parse, so a classical
+welcome's own agent signature also validated it as a PQ welcome.
+
+`PQEstablishmentKeyMaterial` now leads with a checked reserved `0x00` byte — the
+one length prefix a classical key-package `Data` field can never carry — so both
+cross-parse directions reject deterministically at decode, independent of any
+enum raw values. This changes the PQ welcome wire format (the classical welcomes
+are byte-for-byte unchanged); regenerate any PQ welcomes serialized under 1.6.0.

--- a/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/PQAnchorWelcome.swift
@@ -19,7 +19,9 @@ import Foundation
 ///
 ///Signature bodies use fresh discriminators ("PQAnchorReply.*"), so a signature
 ///over a classical `AnchorWelcome` can never validate as a `PQAnchorWelcome`,
-///or vice versa.
+///or vice versa. As a second, independent defense, the key material leads with
+///a checked reserved byte (`PQEstablishmentKeyMaterial.discriminator`, `0x00`)
+///that diverges the Welcome layout from the classical one at parse.
 ///
 ///Same pattern as AnchorHello/AnchorWelcome:
 ///- Inner content that we are transmitting

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -16,9 +16,13 @@ import Foundation
 ///welcome issued in response to a key package; the difference is the signed
 ///content carries `PQEstablishmentKeyMaterial` (the CLASSICAL return key
 ///package plus the commitment to the A.4 bootstrap PQ key package) instead of
-///a bare key-package blob. The layouts also diverge structurally at the fifth
-///content element (nested pair vs Data), so the signed wire bytes of one never
-///parse as the other.
+///a bare key-package blob. The layouts also diverge at the fifth content
+///element, where the key material leads with a checked reserved byte
+///(`PQEstablishmentKeyMaterial.discriminator`, `0x00`) sitting where a
+///classical welcome carries its key-package `Data` length prefix — a byte a
+///classical length prefix can never be — so the signed wire bytes of one
+///route die at parse on the other, deterministically in both directions (see
+///the discriminator's doc).
 public struct PQAppWelcome: Equatable, Sendable {
 	public let introduction: IdentityIntroduction
 	public let signedContent: SignedObject<Content>

--- a/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
+++ b/Sources/CommProtocol/SessionEncryption/PQEstablishmentKeyMaterial.swift
@@ -25,6 +25,28 @@ import Foundation
 ///violation HERE — an immediate, local decode error — not a deep opaque
 ///failure at the A.4 side-band after establishment already succeeded.
 public struct PQEstablishmentKeyMaterial: Equatable, Sendable {
+	///Reserved wire tag leading the encoding; the parse init rejects anything
+	///else. This byte — not enum raw values — is what makes the classical and
+	///PQ welcome layouts mutually unparseable at their divergence point, where
+	///a classical welcome carries a bare key-package `Data`. It MUST be `0x00`,
+	///the one byte a classical `Data` length prefix can never be: `OptionalData`
+	///encodes a non-empty body with a length prefix of `0x01…0xFE` (or `0xFF`
+	///wide-form), and an empty body is rejected upstream — so a leading `0x00`
+	///can only mean PQ key material, never a classical key package. Both
+	///cross-parse directions then reject deterministically, with no reliance on
+	///the signature check:
+	/// - classical bytes read as PQ: the leading byte is the classical length
+	///   prefix (never `0x00`), so this guard fails with `invalidPrefix`;
+	/// - PQ bytes read as classical: a classical `Data` parse reads this `0x00`
+	///   as the `OptionalData` none-marker and throws `requiredValueMissing`.
+	///
+	///A nonzero value would collide: a key package of exactly that length has
+	///that length prefix, so the element round-trips byte-identically through
+	///the PQ parse and the classical agent signature validates as PQ — a
+	///cross-route confusion the signature check does NOT catch. Frozen: changing
+	///it breaks every signed PQ welcome.
+	public static let discriminator: UInt8 = 0x00
+
 	public let keyPackageData: Data
 	public let bootstrapKpCommitment: TypedDigest
 
@@ -55,22 +77,26 @@ public struct PQEstablishmentKeyMaterial: Equatable, Sendable {
 	}
 }
 
-extension PQEstablishmentKeyMaterial: LinearEncodedPair {
-	public var first: Data { keyPackageData }
-	public var second: TypedDigest { bootstrapKpCommitment }
+extension PQEstablishmentKeyMaterial: LinearEncodedTriple {
+	public var first: UInt8 { Self.discriminator }
+	public var second: Data { keyPackageData }
+	public var third: TypedDigest { bootstrapKpCommitment }
 
-	public init(first: Data, second: TypedDigest) throws {
+	public init(first: UInt8, second: Data, third: TypedDigest) throws {
+		guard first == Self.discriminator else {
+			throw LinearEncodingError.invalidPrefix
+		}
 		//pin the commitment's digest type on the wire: today .sha256 is the
 		//only DigestTypes case, so this cannot fire — it exists for the day
 		//the enum grows for some unrelated feature, keeping a non-SHA-256
 		//commitment a decode error here rather than a signed, established
 		//welcome that strands at A.4
-		guard second.type == .sha256 else {
+		guard third.type == .sha256 else {
 			throw LinearEncodingError.invalidPrefix
 		}
 		self.init(
-			keyPackageData: first,
-			bootstrapKpCommitment: second
+			keyPackageData: second,
+			bootstrapKpCommitment: third
 		)
 	}
 }

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -190,16 +190,22 @@ struct PQAnchorWelcomeTests {
 }
 
 struct PQEstablishmentKeyMaterialWireTests {
-	//The commitment's wire contract: prefix byte 0x01 (sha256) + exactly 32
-	//bytes, frozen independent of how DigestTypes evolves. Today the 0x02 case
-	//is rejected by TypedDigest's own unknown-prefix parse; once DigestTypes
-	//grows a second case for any unrelated feature, the .sha256 pin in
-	//PQEstablishmentKeyMaterial's parse init is what keeps this red — the
-	//session layer accepts exactly SHA-256/32, so any other digest must die
-	//at decode, not deep in the A.4 side-band.
-	private func encoded(prefix: UInt8, digestBytes: Int) throws -> Data {
+	//The key material's wire contract: reserved discriminator byte 0x00, then
+	//the key package, then the commitment as prefix byte 0x01 (sha256) +
+	//exactly 32 bytes — all frozen independent of how the prefix enums evolve.
+	//Today the 0x02 case is rejected by TypedDigest's own unknown-prefix
+	//parse; once DigestTypes grows a second case for any unrelated feature,
+	//the .sha256 pin in PQEstablishmentKeyMaterial's parse init is what keeps
+	//this red — the session layer accepts exactly SHA-256/32, so any other
+	//digest must die at decode, not deep in the A.4 side-band.
+	private func encoded(
+		discriminator: UInt8 = PQEstablishmentKeyMaterial.discriminator,
+		prefix: UInt8,
+		digestBytes: Int
+	) throws -> Data {
 		let kp = SymmetricKey(size: .bits256).rawRepresentation
 		var bytes = Data()
+		bytes.append(discriminator)
 		bytes.append(UInt8(kp.count))  //OptionalData short-form length prefix
 		bytes.append(kp)
 		bytes.append(prefix)
@@ -211,6 +217,17 @@ struct PQEstablishmentKeyMaterialWireTests {
 		let material = try PQEstablishmentKeyMaterial.mock()
 		let received = try PQEstablishmentKeyMaterial.finalParse(material.wireFormat)
 		#expect(received == material)
+	}
+
+	@Test func testWrongDiscriminatorFailsParse() throws {
+		//the reserved leading byte is checked, not just skipped: any nonzero
+		//value — including 0x80, which a 128-byte classical key package's
+		//length prefix could take — must die at decode
+		#expect(throws: LinearEncodingError.invalidPrefix) {
+			_ = try PQEstablishmentKeyMaterial.finalParse(
+				try encoded(discriminator: 0x80, prefix: 0x01, digestBytes: 32)
+			)
+		}
 	}
 
 	@Test func testUnknownDigestPrefixFailsParse() throws {

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -48,7 +48,8 @@ struct PQAppWelcomeTests {
 	@Test func testClassicalAppWelcomeIsNotAPQAppWelcome() throws {
 		//domain separation: a classical AppWelcome's bytes must never survive
 		//the PQ parse+validate chain (dies at parse — the classical fifth
-		//element's bytes cannot decode as the PQ key-material pair)
+		//element's key-package length prefix is never 0x00, so it can never
+		//satisfy the PQ key material's reserved discriminator byte)
 		let myAgent = AgentPrivateKey()
 		let classicalWelcome = try AppWelcome.mock(
 			remoteAgentKey: myAgent.publicKey,
@@ -61,10 +62,36 @@ struct PQAppWelcomeTests {
 		}
 	}
 
+	@Test func testCraftedClassicalKeyPackageIsNotAPQAppWelcome() throws {
+		//regression for the fifth-element discriminator. A classical key
+		//package of exactly 128 bytes has OptionalData length prefix 0x80; a
+		//mid-range discriminator (0x80) let that byte pass the PQ check, and
+		//with kp[0]=0x5E and kp[95]=0x01 the element round-tripped
+		//byte-identically, so the classical agent signature also validated as
+		//PQ — a cross-route confusion. 0x00 is the one length prefix
+		//OptionalData never emits for a non-empty body, so no classical key
+		//package of ANY length can be reframed as PQ key material: this dies at
+		//parse.
+		let myAgent = AgentPrivateKey()
+		var kp = Data(repeating: 0xAB, count: 128)
+		kp[kp.startIndex] = 0x5E  //would-be PQ keyPackageData length
+		kp[kp.startIndex + 95] = 0x01  //would-be sha256 digest prefix
+		let classicalWelcome = try AppWelcome.mock(
+			remoteAgentKey: myAgent.publicKey,
+			keyPackageData: kp
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try PQAppWelcome.finalParse(classicalWelcome.wireFormat)
+				.validated(myAgent: myAgent.publicKey)
+		}
+	}
+
 	@Test func testPQAppWelcomeIsNotAClassicalAppWelcome() throws {
 		//the reverse direction: a PQ welcome's bytes must not survive the
-		//CLASSICAL parse+validate chain either (the PQ fifth element leaves
-		//the commitment bytes trailing a classical parse)
+		//CLASSICAL parse+validate chain either — a classical Data parse of the
+		//fifth element reads the 0x00 discriminator as the OptionalData
+		//none-marker and throws requiredValueMissing
 		let myAgent = AgentPrivateKey()
 		let pqWelcome = try PQAppWelcome.mock(
 			remoteAgentKey: myAgent.publicKey,


### PR DESCRIPTION
The PQ establishment welcomes (`PQAppWelcome` / `PQAnchorWelcome`, shipped in 1.6.0) separate from the classical `AppWelcome` / `AnchorWelcome` only by their signed content's fifth element diverging in layout — a divergence that rested on the signing-key and digest prefix enums keeping disjoint raw values. A crafted 128-byte classical key package round-tripped byte-identically through the PQ parse, so a classical welcome's own agent signature also validated it as a PQ welcome (cross-route confusion).

This leads `PQEstablishmentKeyMaterial` with a checked reserved `0x00` byte — the one length prefix a classical key-package `Data` field can never carry — so both cross-parse directions reject deterministically at decode, independent of any enum raw values. It changes the PQ welcome wire format (classical welcomes untouched) and carries a `patch` changeset since the structs are already released in 1.6.0. Includes a regression test built from the exact crafted welcome that previously confused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)