### PR TITLE
Add the born-dedicated establishment delegation (contract 26)

### DIFF
--- a/.changeset/pq-establishment-handoff.md
+++ b/.changeset/pq-establishment-handoff.md
@@ -1,0 +1,5 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Add the born-dedicated establishment delegation (TwoMLSPQ contract 26): `PQCardEstablishmentHandoff` and `PQAnchorEstablishmentHandoff` carry the identity-signed handoff artifact on the establishment staple, next to the unmodified spec-conformant return welcome, with every to-be-signed slot derived from the welcome bytes (`PQEstablishmentBinding`) so the delegation binds the exact group being joined and cannot cross-validate as a steady-state rotation handoff. Create via `AgentPrivateKey.completePQCardEstablishment` / `PrivateActiveAnchor.createPQAnchorEstablishmentHandoff`.

--- a/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
@@ -197,6 +197,44 @@ public struct AgentPrivateKey: Sendable {
 		)
 	}
 
+	///The card arm's born-dedicated establishment delegation (TwoMLSPQ
+	///contract 26): the same two-isolation-domain flow as
+	///`completeAgentHandoff` — the IdentityPrivateKey minted the delegate
+	///(`createAgentDelegate(for:context:)` with
+	///`PQEstablishmentBinding.context(welcome:)`), and the NEW dedicated agent
+	///completes it here — but the artifact rides the establishment staple
+	///instead of a proposal, with the context filled from the welcome and the
+	///update-message slot EMPTY (at establishment the welcome IS the
+	///credential-carrying MLS artifact and is already signed via the context;
+	///see `PQEstablishmentBinding`). Called AFTER the session layer's `receive`
+	///produced the return welcome and BEFORE the session may emit.
+	public func completePQCardEstablishment(
+		input: AgentHandoff.Input,
+		agentData: AgentUpdate,
+		welcome: Data
+	) throws -> PQCardEstablishmentHandoff {
+		//an empty welcome can never be joined; reject locally before signing
+		guard !welcome.isEmpty else {
+			throw LinearEncodingError.requiredValueMissing
+		}
+		let newAgentSignatureOver = try AgentHandoff.NewAgentTBS(
+			knownAgentKey: input.establishedAgent,
+			newAgentIdentity: input.existingIdentity,
+			context: PQEstablishmentBinding.context(welcome: welcome),
+			updateMessage: Data(),
+			agentData: agentData
+		).formatForSigning
+		let newAgentSignature = try sign(input: newAgentSignatureOver)
+
+		return .init(
+			identityDelegate: input.identityDelegate,
+			agentHandoff: .init(
+				agentData: agentData,
+				newAgentSignature: newAgentSignature
+			)
+		)
+	}
+
 	public func completeIdentityHandoff(
 		identityHandoff: IdentityHandoff,
 		establishedAgent: AgentPublicKey,

--- a/Sources/CommProtocol/SessionEncryption/PQEstablishmentHandoff.swift
+++ b/Sources/CommProtocol/SessionEncryption/PQEstablishmentHandoff.swift
@@ -1,0 +1,192 @@
+//
+//  PQEstablishmentHandoff.swift
+//  CommProtocol
+//
+//  Created by Mark @ Germ on 7/20/26.
+//
+
+import Foundation
+
+///The establishment binding for a born-dedicated PQ session's delegation
+///(TwoMLSPQ contract 26). A born-dedicated acceptor's session runs under a
+///freshly-minted dedicated agent from its very first frame, so — unlike every
+///other credential the receive path admits — there is no proposal round to
+///carry the identity-signed handoff. Instead the handoff artifact rides the
+///establishment wire itself, stapled next to the (unmodified, spec-conformant)
+///return welcome, and its signatures BIND THE WELCOME through ONE derivation:
+///the `context` slot carries `sha256(welcome)`, so the delegation cannot be
+///detached from the exact group being joined or replayed against another
+///session.
+///
+///There is deliberately no `updateMessage` binding (ruling 2026-07-20): at
+///establishment the welcome IS the credential-carrying MLS artifact — the role
+///the Upd digest plays in a steady-state rotation — and it is already signed
+///via `context`, so a second welcome-derived fill would bind nothing new. The
+///card arm signs an EMPTY `updateMessage`, which is itself separating: every
+///steady-state fill is a 33-byte digest, so the establishment TBS differs from
+///any rotation TBS in length before collision resistance is even needed — and
+///no other flow verifies an `AgentHandoff` with an empty slot, making the
+///establishment verifier the only door such a signature can pass. The
+///`IdentityDelegate` never had an `updateMessage` slot; its separation rests,
+///as everywhere in this protocol, on the context VALUE (`sha256(welcome)` vs a
+///group-id digest — disjoint preimage spaces under SHA-256).
+public enum PQEstablishmentBinding {
+	///The one establishment binding, filling BOTH arms' slots: the digest of
+	///the exact welcome the initiator will join. Card: the
+	///`IdentityDelegate`/`AgentHandoff` `context`. Anchor: `groupContext` AND
+	///`mlsUpdateDigest` (the slot is a required `TypedDigest`, so the honest
+	///fill is the same single binding value stated at both fixed TBS offsets —
+	///cross-validating as a steady-state handoff would need the welcome digest
+	///to equal a group-id digest and an Upd digest simultaneously). The
+	///verifier recomputes it from the welcome section of the establishment
+	///staple — the value is never transmitted separately, so there is nothing
+	///to substitute.
+	public static func context(welcome: Data) -> TypedDigest {
+		.init(prefix: .sha256, over: welcome)
+	}
+}
+
+///The CARD arm's born-dedicated establishment delegation: the same two
+///artifacts a steady-state card rotation carries — the `IdentityDelegate`
+///(the identity key signs the dedicated agent key + context) and the
+///`AgentHandoff` (the dedicated agent's proof-of-possession signature over
+///the known/invitation agent, the identity, the context, and an EMPTY
+///update-message slot — see `PQEstablishmentBinding` for why empty is both
+///honest and separating) — with the context filled from the welcome. The
+///invitation agent does not sign (steady-state parity: a card predecessor
+///never signs the successor's handoff), but it is NAMED in the signed body
+///(`knownAgentKey`), so the artifact only validates against the invitation
+///agent the initiator already holds.
+///
+///Transport: rides the establishment staple's opaque signed-blob section,
+///next to (never inside) the spec-conformant return welcome. The leading
+///reserved byte makes the two arms' blobs mutually unparseable at their first
+///byte, before any signature check.
+public struct PQCardEstablishmentHandoff: Equatable, Sendable {
+	///Reserved leading wire byte; the parse init rejects anything else.
+	///Distinct from `PQAnchorEstablishmentHandoff.discriminator`, so a blob
+	///for one arm dies deterministically at the other's parse. Frozen.
+	public static let discriminator: UInt8 = 0x01
+
+	let identityDelegate: IdentityDelegate
+	let agentHandoff: AgentHandoff
+
+	public struct Validated: Sendable {
+		///The dedicated agent the identity delegated to. The caller MUST
+		///additionally require this key to equal the welcome's creator-leaf
+		///credential (the session layer's `expectedCreator` re-feed check) —
+		///the signatures prove the identity delegated this key for this
+		///welcome, and only the leaf equality proves the session actually
+		///runs under it.
+		public let newAgent: AgentPublicKey
+		public let agentData: AgentUpdate
+	}
+
+	///Validate against the peer state the initiator already holds: the
+	///acceptor's identity (from the card introduction) and its invitation
+	///agent (the key package's delegated agent), plus the welcome bytes from
+	///the establishment staple's welcome section.
+	public func validated(
+		knownIdentity: IdentityPublicKey,
+		knownAgent: AgentPublicKey,
+		welcome: Data
+	) throws -> Validated {
+		let context = PQEstablishmentBinding.context(welcome: welcome)
+		let newAgent = try identityDelegate.validate(
+			knownIdentity: knownIdentity,
+			context: context
+		)
+		let agentData = try agentHandoff.validate(
+			knownAgent: knownAgent,
+			newAgent: newAgent,
+			newAgentIdentity: knownIdentity,
+			context: context,
+			updateMessage: Data()
+		)
+		return .init(newAgent: newAgent, agentData: agentData)
+	}
+}
+
+extension PQCardEstablishmentHandoff: LinearEncodedTriple {
+	public var first: UInt8 { Self.discriminator }
+	public var second: IdentityDelegate { identityDelegate }
+	public var third: AgentHandoff { agentHandoff }
+
+	public init(first: UInt8, second: IdentityDelegate, third: AgentHandoff) throws {
+		guard first == Self.discriminator else {
+			throw LinearEncodingError.invalidPrefix
+		}
+		self.init(identityDelegate: second, agentHandoff: third)
+	}
+}
+
+///The ANCHOR arm's born-dedicated establishment delegation: the full
+///steady-state `AnchorHandoff` — the invitation (retired) agent, the active
+///anchor, and the dedicated (new) agent all sign — with `groupContext` and
+///`mlsUpdateDigest` both filled with the ONE establishment binding value
+///(`PQEstablishmentBinding.context(welcome:)`; the digest slot is required, so
+///the honest fill is the same value at both fixed TBS offsets).
+public struct PQAnchorEstablishmentHandoff: Equatable, Sendable {
+	///Reserved leading wire byte; see `PQCardEstablishmentHandoff`. Frozen.
+	public static let discriminator: UInt8 = 0x02
+
+	let anchorHandoff: AnchorHandoff
+
+	///Validate against the peer state the initiator already holds: the
+	///acceptor's anchor (from the hello) paired with its invitation agent,
+	///plus the welcome bytes from the establishment staple. The returned
+	///`Verified.agent.agentKey` is the dedicated agent; the caller MUST
+	///additionally require it to equal the welcome's creator-leaf credential
+	///(the session layer's `expectedCreator` re-feed check).
+	public func validated(
+		knownAnchor: PublicAnchorAgent,
+		welcome: Data
+	) throws -> AnchorHandoff.Verified {
+		let context = PQEstablishmentBinding.context(welcome: welcome)
+		return try knownAnchor.verify(
+			anchorHandoff: anchorHandoff,
+			context: context,
+			mlsUpdateDigest: context
+		)
+	}
+}
+
+extension PQAnchorEstablishmentHandoff: LinearEncodedPair {
+	public var first: UInt8 { Self.discriminator }
+	public var second: AnchorHandoff { anchorHandoff }
+
+	public init(first: UInt8, second: AnchorHandoff) throws {
+		guard first == Self.discriminator else {
+			throw LinearEncodingError.invalidPrefix
+		}
+		self.init(anchorHandoff: second)
+	}
+}
+
+extension PrivateActiveAnchor {
+	///Mint the anchor arm's establishment delegation. Called AFTER the session
+	///layer's `receive` produced the return welcome (the welcome must exist to
+	///be signed over) and BEFORE the session may emit — the session layer
+	///refuses to staple until the resulting envelope installs.
+	public func createPQAnchorEstablishmentHandoff(
+		agentUpdate: AgentUpdate,
+		newAgent: AgentPrivateKey,
+		from retiredAgent: PrivateAnchorAgent,
+		welcome: Data
+	) throws -> PQAnchorEstablishmentHandoff {
+		//an empty welcome can never be joined; reject locally before signing
+		guard !welcome.isEmpty else {
+			throw LinearEncodingError.requiredValueMissing
+		}
+		let context = PQEstablishmentBinding.context(welcome: welcome)
+		return .init(
+			anchorHandoff: try createNewAgentHandoff(
+				agentUpdate: agentUpdate,
+				newAgent: newAgent,
+				from: retiredAgent,
+				groupContext: context,
+				mlsUpdateDigest: context
+			)
+		)
+	}
+}

--- a/Tests/CommProtocolTests/SessionEncryption/PQEstablishmentHandoffTests.swift
+++ b/Tests/CommProtocolTests/SessionEncryption/PQEstablishmentHandoffTests.swift
@@ -1,0 +1,317 @@
+//
+//  PQEstablishmentHandoffTests.swift
+//  CommProtocol
+//
+//  Pins the born-dedicated establishment delegation (TwoMLSPQ contract 26):
+//  the identity-signed handoff artifact that rides the establishment staple
+//  next to the spec-conformant return welcome, with every TBS slot derived
+//  from the welcome bytes (`PQEstablishmentBinding`) so the delegation cannot
+//  be detached from the exact group being joined, nor cross-validate as a
+//  steady-state rotation handoff.
+//
+
+import AtprotoTypes
+import AtprotoTypesMocks
+import CommProtocolMocks
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+//MARK: - Card arm
+
+struct PQCardEstablishmentHandoffTests {
+	let identityKey: IdentityPrivateKey
+	let signedIdentity: SignedObject<CoreIdentity>
+	//the acceptor's published card agent — the peer the initiator already knows
+	let invitationAgent = AgentPrivateKey()
+	//the fresh per-session principal the session was born under
+	let dedicatedAgent = AgentPrivateKey()
+	//stands in for the return welcome the session layer produced
+	let welcome = SymmetricKey(size: .bits256).rawRepresentation
+
+	init() throws {
+		(identityKey, signedIdentity) = try Mocks.mockIdentity()
+	}
+
+	private func mint(
+		welcome: Data,
+		agentData: AgentUpdate = .mock()
+	) throws -> PQCardEstablishmentHandoff {
+		let input = AgentHandoff.Input(
+			existingIdentity: signedIdentity.content.id,
+			identityDelegate: try identityKey.createAgentDelegate(
+				for: dedicatedAgent.publicKey,
+				context: PQEstablishmentBinding.context(welcome: welcome)
+			),
+			signedIdentityMutable: nil,
+			establishedAgent: invitationAgent.publicKey
+		)
+		return try dedicatedAgent.completePQCardEstablishment(
+			input: input,
+			agentData: agentData,
+			welcome: welcome
+		)
+	}
+
+	@Test func roundTripValidates() throws {
+		let agentData = AgentUpdate.mock()
+		let handoff = try mint(welcome: welcome, agentData: agentData)
+
+		//wire round-trip before verification, as the initiator sees it
+		let received = try PQCardEstablishmentHandoff.finalParse(
+			try handoff.wireFormat)
+
+		let validated = try received.validated(
+			knownIdentity: signedIdentity.content.id,
+			knownAgent: invitationAgent.publicKey,
+			welcome: welcome
+		)
+		//the delegation names exactly the dedicated agent; the session layer
+		//separately requires this key to equal the welcome's creator leaf
+		#expect(validated.newAgent == dedicatedAgent.publicKey)
+		#expect(validated.agentData == agentData)
+	}
+
+	@Test func rejectsTamperedWelcome() throws {
+		let handoff = try mint(welcome: welcome)
+		//the signatures bind H(welcome): any other welcome must fail, so the
+		//delegation cannot be spliced onto a different establishment
+		var tampered = welcome
+		tampered[tampered.startIndex] ^= 0x01
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(
+				knownIdentity: signedIdentity.content.id,
+				knownAgent: invitationAgent.publicKey,
+				welcome: tampered
+			)
+		}
+	}
+
+	@Test func rejectsWrongIdentity() throws {
+		let handoff = try mint(welcome: welcome)
+		let (_, otherIdentity) = try Mocks.mockIdentity()
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(
+				knownIdentity: otherIdentity.content.id,
+				knownAgent: invitationAgent.publicKey,
+				welcome: welcome
+			)
+		}
+	}
+
+	@Test func rejectsWrongInvitationAgent() throws {
+		//the invitation agent does not sign, but it is NAMED in the signed
+		//body — validating against any other known agent must fail
+		let handoff = try mint(welcome: welcome)
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(
+				knownIdentity: signedIdentity.content.id,
+				knownAgent: AgentPrivateKey().publicKey,
+				welcome: welcome
+			)
+		}
+	}
+
+	@Test func establishmentCannotCrossValidateAsRotation() throws {
+		//a steady-state rotation fills updateMessage with a bare TypedDigest
+		//wire form (the MLS Update digest) and context with the session's
+		//proposal context; the establishment artifact must fail under those
+		//fills — the delegation is not a rotation proposal
+		let handoff = try mint(welcome: welcome)
+		let rotationContext = try TypedDigest.mock()
+		#expect(throws: (any Error).self) {
+			_ = try handoff.agentHandoff.validate(
+				knownAgent: invitationAgent.publicKey,
+				newAgent: dedicatedAgent.publicKey,
+				newAgentIdentity: signedIdentity.content.id,
+				context: rotationContext,
+				updateMessage: rotationContext.wireFormat
+			)
+		}
+		#expect(throws: (any Error).self) {
+			_ = try handoff.identityDelegate.validate(
+				knownIdentity: signedIdentity.content.id,
+				context: rotationContext
+			)
+		}
+		//the length-separation pin: even with the CORRECT establishment
+		//context, a rotation-style 33-byte updateMessage must fail — the
+		//establishment PoP signed an EMPTY slot, so the TBS lengths differ
+		//before any value comparison
+		#expect(throws: (any Error).self) {
+			_ = try handoff.agentHandoff.validate(
+				knownAgent: invitationAgent.publicKey,
+				newAgent: dedicatedAgent.publicKey,
+				newAgentIdentity: signedIdentity.content.id,
+				context: PQEstablishmentBinding.context(welcome: welcome),
+				updateMessage: try TypedDigest.mock().wireFormat
+			)
+		}
+	}
+
+	@Test func rejectsEmptyWelcomeAtCreate() throws {
+		#expect(throws: (any Error).self) {
+			_ = try mint(welcome: Data())
+		}
+	}
+
+	@Test func wireContractPinsLeadingByte() throws {
+		let handoff = try mint(welcome: welcome)
+		let wire = try handoff.wireFormat
+		#expect(wire.first == PQCardEstablishmentHandoff.discriminator)
+		#expect(PQCardEstablishmentHandoff.discriminator == 0x01)
+	}
+
+	@Test func cardBytesRejectAsAnchor() throws {
+		//cross-arm parse dies deterministically at the leading byte, before
+		//any signature machinery runs
+		let wire = try mint(welcome: welcome).wireFormat
+		#expect(throws: (any Error).self) {
+			_ = try PQAnchorEstablishmentHandoff.finalParse(wire)
+		}
+	}
+}
+
+//MARK: - Anchor arm
+
+struct PQAnchorEstablishmentHandoffTests {
+	let acceptorDID = Atproto.DID.mock()
+	let acceptorAnchor: PrivateActiveAnchor
+	//the acceptor's published hello agent — the invitation agent the
+	//initiator already knows, and the RETIRED signer of the handoff
+	let invitationAgent: PrivateAnchorAgent
+	let dedicatedAgent = AgentPrivateKey()
+	let welcome = SymmetricKey(size: .bits256).rawRepresentation
+
+	init() throws {
+		acceptorAnchor = .create(for: acceptorDID)
+		invitationAgent = acceptorAnchor.createHelloAgent()
+	}
+
+	private var knownAnchor: PublicAnchorAgent {
+		.init(
+			anchor: acceptorAnchor.publicAnchor,
+			agentKey: invitationAgent.publicKey
+		)
+	}
+
+	private func mint(
+		welcome: Data,
+		agentUpdate: AgentUpdate = .mock()
+	) throws -> PQAnchorEstablishmentHandoff {
+		try acceptorAnchor.createPQAnchorEstablishmentHandoff(
+			agentUpdate: agentUpdate,
+			newAgent: dedicatedAgent,
+			from: invitationAgent,
+			welcome: welcome
+		)
+	}
+
+	@Test func roundTripVerifies() throws {
+		let agentUpdate = AgentUpdate.mock()
+		let handoff = try mint(welcome: welcome, agentUpdate: agentUpdate)
+
+		let received = try PQAnchorEstablishmentHandoff.finalParse(
+			try handoff.wireFormat)
+
+		let verified = try received.validated(
+			knownAnchor: knownAnchor,
+			welcome: welcome
+		)
+		#expect(verified.agent.agentKey == dedicatedAgent.publicKey)
+		#expect(verified.newAgentUpdate == agentUpdate)
+		//same-anchor establishment: no anchor succession rides the handoff
+		#expect(verified.newAnchor == false)
+	}
+
+	@Test func rejectsTamperedWelcome() throws {
+		let handoff = try mint(welcome: welcome)
+		var tampered = welcome
+		tampered[tampered.startIndex] ^= 0x01
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(knownAnchor: knownAnchor, welcome: tampered)
+		}
+	}
+
+	@Test func rejectsWrongInvitationAgent() throws {
+		//all three signatures bind the known (retired/invitation) agent; a
+		//different one must fail even with the right anchor
+		let handoff = try mint(welcome: welcome)
+		let otherAgent = acceptorAnchor.createHelloAgent()
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(
+				knownAnchor: .init(
+					anchor: acceptorAnchor.publicAnchor,
+					agentKey: otherAgent.publicKey
+				),
+				welcome: welcome
+			)
+		}
+	}
+
+	@Test func rejectsWrongAnchor() throws {
+		let handoff = try mint(welcome: welcome)
+		let otherAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+		#expect(throws: (any Error).self) {
+			_ = try handoff.validated(
+				knownAnchor: .init(
+					anchor: otherAnchor.publicAnchor,
+					agentKey: invitationAgent.publicKey
+				),
+				welcome: welcome
+			)
+		}
+	}
+
+	@Test func establishmentCannotCrossValidateAsRotation() throws {
+		//a steady-state anchor rotation verifies with (groupContext = the
+		//session's group-id digest, mlsUpdateDigest = the MLS Update digest);
+		//the establishment artifact must fail under those fills
+		let handoff = try mint(welcome: welcome)
+		#expect(throws: (any Error).self) {
+			_ = try knownAnchor.verify(
+				anchorHandoff: handoff.anchorHandoff,
+				context: try TypedDigest.mock(),
+				mlsUpdateDigest: try TypedDigest.mock()
+			)
+		}
+	}
+
+	@Test func rejectsEmptyWelcomeAtCreate() throws {
+		#expect(throws: (any Error).self) {
+			_ = try mint(welcome: Data())
+		}
+	}
+
+	@Test func wireContractPinsLeadingByte() throws {
+		let wire = try mint(welcome: welcome).wireFormat
+		#expect(wire.first == PQAnchorEstablishmentHandoff.discriminator)
+		#expect(PQAnchorEstablishmentHandoff.discriminator == 0x02)
+	}
+
+	@Test func anchorBytesRejectAsCard() throws {
+		let wire = try mint(welcome: welcome).wireFormat
+		#expect(throws: (any Error).self) {
+			_ = try PQCardEstablishmentHandoff.finalParse(wire)
+		}
+	}
+}
+
+//MARK: - Cross-arm binding
+
+struct PQEstablishmentBindingTests {
+	@Test func theOneBindingIsDeterministicAndWelcomeSensitive() {
+		let welcome = SymmetricKey(size: .bits256).rawRepresentation
+		let context = PQEstablishmentBinding.context(welcome: welcome)
+
+		//deterministic: signer and verifier independently derive the same
+		//value from the same welcome bytes
+		#expect(PQEstablishmentBinding.context(welcome: welcome) == context)
+		//welcome-sensitive: any other welcome yields a different binding
+		var other = welcome
+		other[other.startIndex] ^= 0x01
+		#expect(PQEstablishmentBinding.context(welcome: other) != context)
+	}
+}


### PR DESCRIPTION
TwoMLSPQ contract 26 makes the born-dedicated acceptor staple a signed establishment envelope next to its (unmodified, spec-conformant) return welcome, closing the delegation-signature gap: the dedicated credential is identity-signed at establishment rather than admitted on the cross-group weld alone. This adds the CommProtocol half — `PQCardEstablishmentHandoff` (IdentityDelegate + new-agent proof-of-possession) and `PQAnchorEstablishmentHandoff` (invitation/retired-agent + anchor + new-agent signatures) — with every TBS slot derived from the welcome bytes via `PQEstablishmentBinding`, so the artifact binds the exact group being joined and is domain-separated from steady-state rotation handoffs at the value level. Negative controls cover welcome tamper, wrong identity/anchor/invitation-agent, cross-arm parse, and rotation cross-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)