### PR TITLE
Drop shared groupId from the PQ card establishment reply

### DIFF
--- a/.changeset/pq-appwelcome-drop-groupid.md
+++ b/.changeset/pq-appwelcome-drop-groupid.md
@@ -1,0 +1,9 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Drop the shared `groupId` from the PQ card establishment reply. `PQAppWelcome.Content` no longer carries a `DataIdentifier groupId` (Quintuple → Quad), and the introduction's signature context switches from `.reply`/`.welcome(groupId:)` to a new seedless `AgentTypes.pqCardEstablishment(remoteAgentId:)` that binds only the answered peer agent (the cross-invitation anti-splice), not a per-session seed.
+
+Rationale: a PQ card session's identity is the crate's LOCAL send-group id (each endpoint keys its own), not a shared, initiator-chosen id transmitted on the wire and used as a shared at-rest record key. The session↔welcome↔identity weld is already the born-dedicated establishment handoff over `sha256(welcome)`, so the seed==groupId cross-check the introduction used to carry is redundant (the agent-signed `Content` plus the handoff pin the establishment).
+
+Wire-breaking for the PQ card reply only; classical `AppWelcome` is unchanged. Adopters must regenerate PQ card invitations/establishments (pre-ship). No new errors. Verified: the full CommProtocol suite passes, including the recipient-binding anti-splice test (`testWrongRecipientAgentFailsValidation`), which confirms the peer-agent binding survives the seed removal.

--- a/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/PQAppWelcome.swift
@@ -28,7 +28,11 @@ public struct PQAppWelcome: Equatable, Sendable {
 	public let signedContent: SignedObject<Content>
 
 	public struct Content: Equatable, Sendable {
-		public let groupId: DataIdentifier
+		//No `groupId`: unlike classical `AppWelcome`, a PQ card session's identity is
+		//the crate's LOCAL send-group id (each endpoint keys its own), not a shared,
+		//initiator-chosen id carried on the wire. The session↔welcome↔identity weld is
+		//the born-dedicated establishment handoff over `sha256(welcome)`, so no shared
+		//session-id field is needed here (2026-07-21).
 		public let agentData: AgentUpdate
 		public let seqNo: UInt32  //sets the initial seqNo
 		//just as messages assert local send time; kept for template parity
@@ -62,26 +66,23 @@ extension PQAppWelcome: LinearEncodedPair {
 	}
 }
 
-extension PQAppWelcome.Content: LinearEncodedQuintuple {
-	public var first: DataIdentifier { groupId }
-	public var second: AgentUpdate { agentData }
-	public var third: UInt32 { seqNo }
-	public var fourth: WireDate { sentTime }
-	public var fifth: PQEstablishmentKeyMaterial { keyMaterial }
+extension PQAppWelcome.Content: LinearEncodedQuad {
+	public var first: AgentUpdate { agentData }
+	public var second: UInt32 { seqNo }
+	public var third: WireDate { sentTime }
+	public var fourth: PQEstablishmentKeyMaterial { keyMaterial }
 
 	public init(
-		first: DataIdentifier,
-		second: AgentUpdate,
-		third: UInt32,
-		fourth: WireDate,
-		fifth: PQEstablishmentKeyMaterial
+		first: AgentUpdate,
+		second: UInt32,
+		third: WireDate,
+		fourth: PQEstablishmentKeyMaterial
 	) throws {
 		self.init(
-			groupId: first,
-			agentData: second,
-			seqNo: third,
-			sentTime: fourth,
-			keyMaterial: fifth
+			agentData: first,
+			seqNo: second,
+			sentTime: third,
+			keyMaterial: fourth
 		)
 	}
 }
@@ -110,10 +111,11 @@ extension PQAppWelcome {
 	}
 
 	public func validated(myAgent: AgentPublicKey) throws -> Validated {
-		let agentType = AgentTypes.welcome(
-			remoteAgentId: myAgent,
-			groupId: signedContent.content.groupId
-		)
+		//Seedless PQ establishment context: binds the acceptor's own agent
+		//(`myAgent`, the peer the replier answered) and, via `generateContext`,
+		//the replier's delegated agent — no session seed (the identity↔welcome
+		//weld is the establishment handoff over the welcome digest).
+		let agentType = AgentTypes.pqCardEstablishment(remoteAgentId: myAgent)
 
 		guard
 			let context = try agentType.generateContext(
@@ -141,11 +143,9 @@ extension AgentPrivateKey {
 	public func createPQAppWelcome(
 		introduction: IdentityIntroduction,
 		agentData: AgentUpdate,
-		groupId: DataIdentifier,
 		keyMaterial: PQEstablishmentKeyMaterial
 	) throws -> PQAppWelcome {
 		let content = PQAppWelcome.Content(
-			groupId: groupId,
 			agentData: agentData,
 			seqNo: .random(in: .min...(.max)),
 			sentTime: .now,

--- a/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
+++ b/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
@@ -13,6 +13,17 @@ public enum AgentTypes {
 	case hello
 	case reply(remoteAgentId: AgentPublicKey, seed: DataIdentifier)
 	case welcome(remoteAgentId: AgentPublicKey, groupId: DataIdentifier)
+	//The PQ card establishment introduction: binds the peer agent it answers
+	//(cross-invitation anti-splice) but carries NO session seed. Used by BOTH sides
+	//(the replier mints with it, the acceptor's `PQAppWelcome.validated` reconstructs
+	//it), so a single seedless case suffices — there is no seed to differ between the
+	//`.reply`/`.welcome` roles. The session identity is now the crate's LOCAL send-group
+	//id and the welcome↔identity weld is the establishment handoff over
+	//`sha256(welcome)`, so a per-session seed here is redundant (agent-signed Content +
+	//the handoff already pin the establishment). No collision with `.reply`/`.welcome`:
+	//those prepend a ≥16-byte non-empty `DataIdentifier`, so a 3-input context can never
+	//equal this 2-input one.
+	case pqCardEstablishment(remoteAgentId: AgentPublicKey)
 
 	public func generateContext(
 		myAgentId: AgentPublicKey
@@ -31,6 +42,14 @@ public enum AgentTypes {
 		case .welcome(let remoteAgentId, let groupId):
 			var hasher = SHA256()
 			hasher.update(data: groupId.identifier)
+			hasher.update(data: remoteAgentId.wireFormat)
+			hasher.update(data: myAgentId.wireFormat)
+			return try .init(
+				prefix: .sha256,
+				checkedData: hasher.finalize().data
+			)
+		case .pqCardEstablishment(let remoteAgentId):
+			var hasher = SHA256()
 			hasher.update(data: remoteAgentId.wireFormat)
 			hasher.update(data: myAgentId.wireFormat)
 			return try .init(

--- a/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
+++ b/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
@@ -20,9 +20,8 @@ public enum AgentTypes {
 	//`.reply`/`.welcome` roles. The session identity is now the crate's LOCAL send-group
 	//id and the welcome↔identity weld is the establishment handoff over
 	//`sha256(welcome)`, so a per-session seed here is redundant (agent-signed Content +
-	//the handoff already pin the establishment). No collision with `.reply`/`.welcome`:
-	//those prepend a ≥16-byte non-empty `DataIdentifier`, so a 3-input context can never
-	//equal this 2-input one.
+	//the handoff already pin the establishment). Domain-separated from `.reply`/`.welcome`
+	//by a leading label (below) so a seedless context can never be reused as a seeded one.
 	case pqCardEstablishment(remoteAgentId: AgentPublicKey)
 
 	public func generateContext(
@@ -50,6 +49,10 @@ public enum AgentTypes {
 			)
 		case .pqCardEstablishment(let remoteAgentId):
 			var hasher = SHA256()
+			//explicit domain separator (matching `Data("delegate".utf8)` etc.); its
+			//length (≠ a 16/32-byte DataIdentifier) also structurally prevents any
+			//overlap with a seeded `.reply`/`.welcome` preimage.
+			hasher.update(data: Data("pqCardEstablishment".utf8))
 			hasher.update(data: remoteAgentId.wireFormat)
 			hasher.update(data: myAgentId.wireFormat)
 			return try .init(

--- a/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
+++ b/Sources/CommProtocolMocks/PQAppWelcome+Mock.swift
@@ -17,23 +17,19 @@ extension PQAppWelcome {
 			try Mocks
 			.mockIdentity()
 
-		let groupId = DataIdentifier(width: .bits256)
-
 		let (agentKey, introduction) =
 			try identityKey
 			.createNewDelegate(
 				signedIdentity: signedIdentity,
 				identityMutable: .mock(),
-				agentType: .welcome(
-					remoteAgentId: remoteAgentKey,
-					groupId: groupId
+				agentType: .pqCardEstablishment(
+					remoteAgentId: remoteAgentKey
 				)
 			)
 
 		return try agentKey.createPQAppWelcome(
 			introduction: introduction,
 			agentData: .mock(),
-			groupId: groupId,
 			keyMaterial: keyMaterial
 		)
 	}

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -119,11 +119,10 @@ struct PQAppWelcomeTests {
 		var flipped = original.keyMaterial.bootstrapKpCommitment.digest
 		flipped[flipped.startIndex] ^= 0x01
 		let tamperedContent = try PQAppWelcome.Content(
-			first: original.groupId,
-			second: original.agentData,
-			third: original.seqNo,
-			fourth: original.sentTime,
-			fifth: try PQEstablishmentKeyMaterial(
+			first: original.agentData,
+			second: original.seqNo,
+			third: original.sentTime,
+			fourth: try PQEstablishmentKeyMaterial(
 				keyPackageData: original.keyMaterial.keyPackageData,
 				bootstrapKpCommitment: flipped
 			)


### PR DESCRIPTION
A PQ card session's identity is the crate's LOCAL send-group id (each endpoint keys its own), not a shared id transmitted on the wire and reused as a shared at-rest record key. And the session↔welcome↔identity weld is already the born-dedicated establishment handoff over `sha256(welcome)`, so the per-session seed the introduction used to carry is redundant. This drops the shared id from the PQ card reply:

- `PQAppWelcome.Content` loses `groupId` (`LinearEncodedQuintuple` → `LinearEncodedQuad`); `createPQAppWelcome` and the mock drop the parameter.
- New seedless `AgentTypes.pqCardEstablishment(remoteAgentId:)` binds only the answered peer agent (the cross-invitation anti-splice) — no session seed. Used by both the replier's mint and `validated()`, and domain-separated from `.reply`/`.welcome` by a leading `"pqCardEstablishment"` label.
- `PQAppWelcome.validated()` reconstructs the context with the new case instead of `.welcome(groupId:)`.

Wire-breaking for the PQ card reply only — classical `AppWelcome` is unchanged, and adopters regenerate PQ card establishments (pre-ship). The full suite passes (101 tests / 28 suites), including `testWrongRecipientAgentFailsValidation`, which confirms the peer-agent binding survives the seed removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)