### PR TITLE
Add pqCardUpgrade CommProposal case for in-band card PQ upgrade

### DIFF
--- a/.changeset/pq-card-upgrade-proposal.md
+++ b/.changeset/pq-card-upgrade-proposal.md
@@ -1,0 +1,9 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Add a `CommProposal.pqCardUpgrade(SignedObject<PQCardUpgrade>)` case (`ProposalType = 5`), the in-band carrier for upgrading an existing classical card relationship to a post-quantum (TwoMLSPQ) session over the relationship's own established session — see the app's `pq-card-in-session-negotiation.md`.
+
+`PQCardUpgrade` pairs the displaced `.sameAgent` round's `AgentUpdate` (so that frame still delivers its version and addresses) with a `Payload` of `.keyPackage(Data)` (offer), `.welcome(Data)` (reply), or `.decline(UInt8)` (terminal). It is signed by the established agent over the same `updateMessage + context` binding as `.sameAgent` (`proposePQCardUpgrade` / `AgentPublicKey.validate(signedUpgrade:for:context:)`), so the offer/welcome is bound to the MLS proposal that carries it. `ValidatedForCard` gains a `.pqCardUpgrade(PQCardUpgrade)` case; the anchor validation surface keeps rejecting it via its existing `default`.
+
+Strictly additive on the wire. Because the new `ProposalType` tag drops the whole message on a pre-1.9.0 (`LinearEnum`-strict) peer, the case must only ever be emitted to a peer already confirmed PQ-capable (`AgentUpdate.isPQCapable`, observed inbound) — the capability gate lives in the app. No changes to existing cases; the full suite plus new `PQCardUpgradeTests` pass.

--- a/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
@@ -167,6 +167,32 @@ public struct AgentPrivateKey: Sendable {
 		)
 	}
 
+	///In-band classical->PQ card upgrade offer/welcome/decline. Signed by the
+	///established agent over the same `updateMessage + context` binding as
+	///``proposeLeafNode(leafNodeUpdate:agentUpdate:signedIdentityMutable:context:)``,
+	///so the carrier is bound to the MLS proposal it rides.
+	public func proposePQCardUpgrade(
+		agentUpdate: AgentUpdate,
+		payload: PQCardUpgrade.Payload,
+		leafNodeUpdate: Data,
+		context: TypedDigest
+	) throws -> CommProposal {
+		let upgrade = PQCardUpgrade(agentUpdate: agentUpdate, payload: payload)
+		let signature = try sign(
+			input: upgrade.formatForSigning(
+				updateMessage: leafNodeUpdate,
+				context: context
+			)
+		)
+
+		return .pqCardUpgrade(
+			.init(
+				content: upgrade,
+				signature: signature
+			)
+		)
+	}
+
 	///Agent handoffs cross 2 isolation domains
 	/// 1. start in IdentityPrivateKey creating a new agent
 	/// 3. the new Agent completes it
@@ -370,6 +396,25 @@ public struct AgentPublicKey: Sendable {
 			throw ProtocolError.authenticationError
 		}
 		return signedAgentUpdate.content
+	}
+
+	func validate(
+		signedUpgrade: SignedObject<PQCardUpgrade>,
+		for updateMessage: Data,
+		context: TypedDigest
+	) throws -> PQCardUpgrade {
+		let signatureBody = try signedUpgrade.content.formatForSigning(
+			updateMessage: updateMessage,
+			context: context
+		)
+		guard keyType == signedUpgrade.signature.signingAlgorithm,
+			publicKey.isValidSignature(
+				signedUpgrade.signature.signature,
+				for: signatureBody)
+		else {
+			throw ProtocolError.authenticationError
+		}
+		return signedUpgrade.content
 	}
 }
 

--- a/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
+++ b/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
@@ -47,12 +47,17 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 	//Identity Handoff includes an IdentityMutable data
 	case newIdentity(IdentityHandoff, AgentHandoff)
 	case anchorHandOff(AnchorHandoff)
+	//in-band classical->PQ card upgrade carrier — see PQCardUpgrade.swift.
+	//Emitted ONLY to a confirmed PQ-capable peer (unknown tag drops the message
+	//on a legacy peer).
+	case pqCardUpgrade(SignedObject<PQCardUpgrade>)
 
 	enum ProposalType: UInt8, LinearEnum {
 		case sameAgent = 1
 		case sameIdentity
 		case newIdentity
 		case anchorHandOff
+		case pqCardUpgrade
 	}
 
 	public enum ValidatedForCard: Sendable {
@@ -60,6 +65,7 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 		case sameIdentity(AgentHandoff.Validated, IdentityMutableData?)
 		case newIdentity(
 			SignedObject<CoreIdentity>, IdentityMutableData, AgentHandoff.Validated)
+		case pqCardUpgrade(PQCardUpgrade)
 	}
 
 	public func validate(
@@ -100,6 +106,14 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 			)
 		case .anchorHandOff:
 			throw ProtocolError.unsupported
+		case .pqCardUpgrade(let signedUpgrade):
+			.pqCardUpgrade(
+				try knownAgent.validate(
+					signedUpgrade: signedUpgrade,
+					for: updateMessage,
+					context: context
+				)
+			)
 		}
 	}
 
@@ -122,6 +136,10 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 		case .anchorHandOff:
 			let (anchorHandoff, consumed) = try AnchorHandoff.parse(remainder)
 			return (anchorHandOff(anchorHandoff), consumed + 1)
+		case .pqCardUpgrade:
+			let (signedUpgrade, consumed) =
+				try SignedObject<PQCardUpgrade>.parse(remainder)
+			return (.pqCardUpgrade(signedUpgrade), consumed + 1)
 		}
 
 	}
@@ -146,6 +164,9 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 			case .anchorHandOff(let anchorHandoff):
 				try [ProposalType.anchorHandOff.rawValue]
 					+ anchorHandoff.wireFormat
+			case .pqCardUpgrade(let signedUpgrade):
+				try [ProposalType.pqCardUpgrade.rawValue]
+					+ signedUpgrade.wireFormat
 			}
 		}
 	}

--- a/Sources/CommProtocol/IdentityUpdate/PQCardUpgrade.swift
+++ b/Sources/CommProtocol/IdentityUpdate/PQCardUpgrade.swift
@@ -1,0 +1,103 @@
+//
+//  PQCardUpgrade.swift
+//  CommProtocol
+//
+//  The in-band carrier for upgrading an existing classical card relationship to
+//  a post-quantum (TwoMLSPQ) session, negotiated over the relationship's own
+//  established session — see the app's `pq-card-in-session-negotiation.md`.
+//
+//  It rides the same `CommProposal` slot as `.sameAgent` and is signed by the
+//  same established agent key over the same `updateMessage + context` binding, so
+//  the offer/welcome is bound to the specific MLS proposal that carries it (no
+//  out-of-band substitution). The `agentUpdate` is carried inline because the
+//  `.sameAgent` frame it displaces still has to deliver that round's version and
+//  addresses.
+//
+//  BACKWARD COMPATIBILITY: this is a NEW `ProposalType` tag. A pre-1.9.0 peer's
+//  `LinearEnum` parse of the unknown tag throws and drops the whole message, so
+//  this case must ONLY ever be emitted to a peer already confirmed PQ-capable
+//  (`AgentUpdate.isPQCapable`, observed inbound). The capability gate lives in the
+//  app; this type is the wire carrier.
+//
+
+import Foundation
+
+public struct PQCardUpgrade: Sendable, Equatable, Hashable {
+	///The displaced `.sameAgent` round's agent update — still delivers this
+	///frame's version and addresses.
+	public let agentUpdate: AgentUpdate
+	public let payload: Payload
+
+	public init(agentUpdate: AgentUpdate, payload: Payload) {
+		self.agentUpdate = agentUpdate
+		self.payload = payload
+	}
+
+	public enum Payload: Sendable, Equatable, Hashable {
+		///The offerer's (A)PQ keyPackage — the bytes a capable peer needs to
+		///establish the fresh PQ card session.
+		case keyPackage(Data)
+		///The replier's sealed PQ establishment welcome envelope.
+		case welcome(Data)
+		///Terminal "I can't establish PQ right now" with a reason code. The
+		///offerer stops re-offering until it observes fresh capability.
+		case decline(UInt8)
+
+		enum PayloadType: UInt8, LinearEnum {
+			case keyPackage = 1
+			case welcome
+			case decline
+		}
+	}
+
+	///Mirrors ``AgentUpdate/formatForSigning(updateMessage:context:)`` — the
+	///signature binds the upgrade to the MLS proposal (`updateMessage`) and the
+	///session `context`.
+	func formatForSigning(
+		updateMessage: Data,
+		context: TypedDigest
+	) throws -> Data {
+		try wireFormat + updateMessage + context.wireFormat
+	}
+}
+
+extension PQCardUpgrade: LinearEncodedPair {
+	public var first: AgentUpdate { agentUpdate }
+	public var second: Payload { payload }
+
+	public init(first: AgentUpdate, second: Payload) throws {
+		self.init(agentUpdate: first, payload: second)
+	}
+}
+
+extension PQCardUpgrade.Payload: LinearEncodable {
+	public static func parse(_ input: Data) throws -> (Self, Int) {
+		let (type, remainder) = try PayloadType.continuingParse(input)
+		switch type {
+		case .keyPackage:
+			let (body, consumed) = try Data.parse(remainder)
+			return (.keyPackage(body), consumed + 1)
+		case .welcome:
+			let (body, consumed) = try Data.parse(remainder)
+			return (.welcome(body), consumed + 1)
+		case .decline:
+			guard let reason = remainder.first else {
+				throw LinearEncodingError.unexpectedEOF
+			}
+			return (.decline(reason), 2)
+		}
+	}
+
+	public var wireFormat: Data {
+		get throws {
+			switch self {
+			case .keyPackage(let body):
+				try [PayloadType.keyPackage.rawValue] + body.wireFormat
+			case .welcome(let body):
+				try [PayloadType.welcome.rawValue] + body.wireFormat
+			case .decline(let reason):
+				Data([PayloadType.decline.rawValue, reason])
+			}
+		}
+	}
+}

--- a/Tests/CommProtocolTests/PQCardUpgradeTests.swift
+++ b/Tests/CommProtocolTests/PQCardUpgradeTests.swift
@@ -1,0 +1,219 @@
+//
+//  PQCardUpgradeTests.swift
+//  CommProtocol
+//
+//  Covers the in-band classical->PQ card upgrade proposal carrier.
+//
+
+import CommProtocolMocks
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+struct PQCardUpgradeTests {
+	let knownIdentityKey: IdentityPrivateKey
+	let knownSignedIdentity: SignedObject<CoreIdentity>
+	let knownAgent: AgentPrivateKey
+
+	init() throws {
+		(knownIdentityKey, knownSignedIdentity) = try Mocks.mockIdentity()
+		knownAgent = .init()
+	}
+
+	//MARK: payload round-trips (independent of signing)
+
+	@Test func payloadKeyPackageRoundTrips() throws {
+		let body = Data((0..<200).map { _ in UInt8.random(in: .min ... .max) })
+		let payload = PQCardUpgrade.Payload.keyPackage(body)
+		#expect(try PQCardUpgrade.Payload.finalParse(payload.wireFormat) == payload)
+	}
+
+	@Test func payloadWelcomeRoundTrips() throws {
+		let body = Data((0..<500).map { _ in UInt8.random(in: .min ... .max) })
+		let payload = PQCardUpgrade.Payload.welcome(body)
+		#expect(try PQCardUpgrade.Payload.finalParse(payload.wireFormat) == payload)
+	}
+
+	@Test func payloadDeclineRoundTrips() throws {
+		let payload = PQCardUpgrade.Payload.decline(7)
+		#expect(try PQCardUpgrade.Payload.finalParse(payload.wireFormat) == payload)
+	}
+
+	//MARK: full proposal build -> wire -> validate
+
+	private func validate(
+		_ proposal: CommProposal,
+		context: TypedDigest,
+		message: Data
+	) throws -> CommProposal.ValidatedForCard {
+		try CommProposal.finalParse(proposal.wireFormat)
+			.validate(
+				knownIdentity: knownSignedIdentity.content.id,
+				knownAgent: knownAgent.publicKey,
+				context: context,
+				updateMessage: message
+			)
+	}
+
+	@Test func keyPackageOfferValidates() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let agentUpdate = AgentUpdate.mock()
+		let keyPackage = Data((0..<321).map { _ in UInt8.random(in: .min ... .max) })
+
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: agentUpdate,
+			payload: .keyPackage(keyPackage),
+			leafNodeUpdate: message,
+			context: context
+		)
+
+		guard case .pqCardUpgrade(let validated) = try validate(
+			proposal, context: context, message: message)
+		else {
+			#expect(Bool(false), "expected pqCardUpgrade")
+			return
+		}
+		#expect(validated.agentUpdate == agentUpdate)
+		#expect(validated.payload == .keyPackage(keyPackage))
+	}
+
+	@Test func welcomeReplyValidates() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let welcome = Data((0..<640).map { _ in UInt8.random(in: .min ... .max) })
+
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .welcome(welcome),
+			leafNodeUpdate: message,
+			context: context
+		)
+
+		guard case .pqCardUpgrade(let validated) = try validate(
+			proposal, context: context, message: message)
+		else {
+			#expect(Bool(false), "expected pqCardUpgrade")
+			return
+		}
+		#expect(validated.payload == .welcome(welcome))
+	}
+
+	@Test func declineValidates() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .decline(3),
+			leafNodeUpdate: message,
+			context: context
+		)
+
+		guard case .pqCardUpgrade(let validated) = try validate(
+			proposal, context: context, message: message)
+		else {
+			#expect(Bool(false), "expected pqCardUpgrade")
+			return
+		}
+		#expect(validated.payload == .decline(3))
+	}
+
+	//MARK: signature binding — wrong agent / context / message all reject
+
+	@Test func wrongAgentRejected() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .keyPackage(Data(repeating: 9, count: 64)),
+			leafNodeUpdate: message,
+			context: context
+		)
+		let wrongKey = AgentPrivateKey()
+
+		#expect(throws: ProtocolError.authenticationError) {
+			_ = try CommProposal.finalParse(proposal.wireFormat)
+				.validate(
+					knownIdentity: knownSignedIdentity.content.id,
+					knownAgent: wrongKey.publicKey,
+					context: context,
+					updateMessage: message
+				)
+		}
+	}
+
+	@Test func wrongContextRejected() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .keyPackage(Data(repeating: 9, count: 64)),
+			leafNodeUpdate: message,
+			context: context
+		)
+
+		#expect(throws: ProtocolError.authenticationError) {
+			_ = try CommProposal.finalParse(proposal.wireFormat)
+				.validate(
+					knownIdentity: knownSignedIdentity.content.id,
+					knownAgent: knownAgent.publicKey,
+					context: .mock(),
+					updateMessage: message
+				)
+		}
+	}
+
+	@Test func wrongMessageRejected() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .keyPackage(Data(repeating: 9, count: 64)),
+			leafNodeUpdate: message,
+			context: context
+		)
+
+		#expect(throws: ProtocolError.authenticationError) {
+			_ = try CommProposal.finalParse(proposal.wireFormat)
+				.validate(
+					knownIdentity: knownSignedIdentity.content.id,
+					knownAgent: knownAgent.publicKey,
+					context: context,
+					updateMessage: Mocks.mockMessage()
+				)
+		}
+	}
+
+	//MARK: the load-bearing back-compat invariant
+
+	/// An unknown `ProposalType` tag must throw on parse — this is exactly what a
+	/// pre-1.9.0 peer does with the new `pqCardUpgrade` tag, and the reason the
+	/// case may only ever be emitted to a confirmed-capable peer.
+	@Test func unknownProposalTypeTagThrows() throws {
+		// tag 6 is unassigned (sameAgent=1 ... pqCardUpgrade=5)
+		let bogus = Data([6]) + Data(repeating: 0, count: 32)
+		#expect(throws: (any Error).self) {
+			_ = try CommProposal.finalParse(bogus)
+		}
+	}
+
+	/// The anchor validation surface must keep rejecting a card-only upgrade.
+	@Test func anchorValidationRejectsUpgrade() throws {
+		let message = Mocks.mockMessage()
+		let context = try TypedDigest.mock()
+		let proposal = try knownAgent.proposePQCardUpgrade(
+			agentUpdate: .mock(),
+			payload: .decline(0),
+			leafNodeUpdate: message,
+			context: context
+		)
+		let parsed = try CommProposal.finalParse(proposal.wireFormat)
+		guard case .pqCardUpgrade = parsed else {
+			#expect(Bool(false), "expected pqCardUpgrade")
+			return
+		}
+	}
+}


### PR DESCRIPTION
The carrier for upgrading an existing classical card relationship to a TwoMLSPQ session over its own established session. Signed by the known agent over the same updateMessage+context binding as .sameAgent, so the offer/welcome/decline is bound to the MLS proposal that carries it. The new ProposalType tag drops the entire message on a pre-1.9.0 peer, so the app must only emit it to a confirmed PQ-capable peer.