### PR TITLE
Add opaque-digest handoff bodies with corrected discriminators

### DIFF
--- a/.changeset/opaque-handoff-bodies.md
+++ b/.changeset/opaque-handoff-bodies.md
@@ -1,5 +1,5 @@
 ---
-"@germ-network/comm-protocol": minor
+"@germ-network/autonomous-comm-protocol": minor
 ---
 
 Add opaque-digest handoff bodies (v2), with corrected discriminators.

--- a/.changeset/opaque-handoff-bodies.md
+++ b/.changeset/opaque-handoff-bodies.md
@@ -1,0 +1,36 @@
+---
+"@germ-network/comm-protocol": minor
+---
+
+Add opaque-digest handoff bodies (v2), with corrected discriminators.
+
+`createNewAgentHandoff` and `PublicAnchorAgent.verify(anchorHandoff:…)` gain
+overloads taking `groupContext`/`mlsUpdateDigest` as `Data` instead of
+`TypedDigest`. The new v2 signature bodies commit to those bytes as length-framed
+values and never interpret them.
+
+The motivation is ownership. A digest's algorithm is a facet of the MLS backend's
+cipher suite, so requiring a `TypedDigest` meant the backend could not adopt a new
+suite until this package shipped a matching `DigestTypes` case — a release
+dependency in the wrong direction. Committing to opaque bytes removes it: the
+caller's own self-describing encoding travels inside the value, so cross-era
+signatures stay unambiguous without this package knowing the eras.
+
+This is safe because a verifier never parses a digest out of a handoff — it
+rebuilds the signature body from its own locally derived reference digest and
+checks the signature against that. Agreement on the algorithm is enforced where
+the session is established, not here.
+
+**Nothing existing changes.** The typed overloads, the v1 bodies, and their
+discriminators are untouched, so every already-issued handoff keeps verifying.
+v1 and v2 are mutually unverifiable by construction (distinct discriminators),
+which is pinned by tests in both directions.
+
+**Discriminator note.** v1's `ActiveAgentBody` and `RetiredAgentBody` carry each
+other's names. That is a labeling bug, not a security one — domain separation
+needs the committed strings to be distinct, not correctly named, and they are —
+but it is now frozen and commented as such, because renaming in place would
+silently fail verification for every live relationship. The v2 bodies carry the
+corrected names, `.v2`-suffixed: the plain corrected strings are unavailable
+precisely because v1 has them live on the opposite structs. A test asserts all six
+are pairwise distinct.

--- a/Sources/CommProtocol/Anchors/Agent/AnchorAgent.swift
+++ b/Sources/CommProtocol/Anchors/Agent/AnchorAgent.swift
@@ -164,6 +164,12 @@ extension PublicAnchorAgent {
 		context: Data,
 		mlsUpdateDigest: Data
 	) throws -> AnchorHandoff.Verified {
+		// Mirror of the mint-side guard: an empty reference digest could only ever
+		// match a handoff minted with the same integration bug, and that pair would
+		// verify with the MLS binding silently absent.
+		guard !context.isEmpty, !mlsUpdateDigest.isEmpty else {
+			throw ProtocolError.unexpected("empty digest bytes in opaque handoff body")
+		}
 		let verifiedPackage = try verifyPackageV2(
 			handoff: anchorHandoff,
 			mlsUpdateDigest: mlsUpdateDigest

--- a/Sources/CommProtocol/Anchors/Agent/AnchorAgent.swift
+++ b/Sources/CommProtocol/Anchors/Agent/AnchorAgent.swift
@@ -151,6 +151,90 @@ extension PublicAnchorAgent {
 		)
 	}
 
+	/// Verify a handoff minted by the OPAQUE overload of `createNewAgentHandoff` (v2 bodies).
+	///
+	/// `context` and `mlsUpdateDigest` are the verifier's OWN locally derived reference values —
+	/// they are never read out of the handoff, which carries no digests at all. Supply the bytes
+	/// this side's MLS backend produced (TwoMLSPQ: the receiver's
+	/// `QueuedRemoteProposal.context`/`.digest`); the signature check does the comparison, so
+	/// wrong bytes simply fail to verify. This is why the bodies can commit to an algorithm this
+	/// package cannot name.
+	public func verify(
+		anchorHandoff: AnchorHandoff,
+		context: Data,
+		mlsUpdateDigest: Data
+	) throws -> AnchorHandoff.Verified {
+		let verifiedPackage = try verifyPackageV2(
+			handoff: anchorHandoff,
+			mlsUpdateDigest: mlsUpdateDigest
+		)
+
+		let content = verifiedPackage.first
+		let newAnchor = try verify(newAnchor: content.second)
+		let activeAnchor = newAnchor?.publicKey ?? anchor.publicKey
+
+		guard
+			activeAnchor
+				.verifier(
+					verifiedPackage.second,
+					try content.activeAnchorBodyV2(
+						groupContext: context,
+						knownAgent: agentKey
+					).wireFormat
+				)
+		else {
+			throw ProtocolError.authenticationError
+		}
+
+		let newAgentKey = try AgentPublicKey(
+			archive: content.first.first
+		)
+		guard
+			newAgentKey.verifier(
+				verifiedPackage.third,
+				try content
+					.activeAgentBodyV2(
+						groupContext: context,
+						mlsUpdateDigest: mlsUpdateDigest,
+						knownAgent: agentKey
+					).wireFormat
+			)
+		else {
+			throw ProtocolError.authenticationError
+		}
+
+		return .init(
+			newAnchor: newAnchor != nil,
+			agent: .init(
+				anchor: newAnchor ?? anchor,
+				agentKey: newAgentKey
+			),
+			newAgentUpdate: content.first.second
+		)
+	}
+
+	private func verifyPackageV2(
+		handoff: AnchorHandoff,
+		mlsUpdateDigest: Data
+	) throws -> AnchorHandoff.Package {
+		guard
+			agentKey.verifier(
+				handoff.first,
+				try AnchorHandoff
+					.RetiredAgentBodyV2(
+						encodedPackage: handoff.second,
+						mlsUpdateDigest: mlsUpdateDigest,
+						knownAgent: agentKey
+					)
+					.wireFormat
+			)
+		else {
+			throw ProtocolError.authenticationError
+		}
+
+		return try .finalParse(handoff.second)
+	}
+
 	private func verifyPackage(
 		handoff: AnchorHandoff,
 		mlsUpdateDigest: TypedDigest

--- a/Sources/CommProtocol/Anchors/Exchange/AnchorHandoff.swift
+++ b/Sources/CommProtocol/Anchors/Exchange/AnchorHandoff.swift
@@ -70,6 +70,34 @@ extension AnchorHandoff {
 				fifth: knownAgent.id
 			)
 		}
+
+		// MARK: v2 — opaque digest bodies
+
+		func activeAnchorBodyV2(
+			groupContext: Data,
+			knownAgent: AgentPublicKey,
+		) throws -> ActiveAnchorBodyV2 {
+			.init(
+				first: ActiveAnchorBodyV2.discriminator,
+				second: self,
+				third: groupContext,
+				fourth: knownAgent.id
+			)
+		}
+
+		func activeAgentBodyV2(
+			groupContext: Data,
+			mlsUpdateDigest: Data,
+			knownAgent: AgentPublicKey,
+		) throws -> ActiveAgentBodyV2 {
+			.init(
+				first: ActiveAgentBodyV2.discriminator,
+				second: self,
+				third: groupContext,
+				fourth: mlsUpdateDigest,
+				fifth: knownAgent.id
+			)
+		}
 	}
 
 	public struct Package: LinearEncodedTriple {
@@ -127,6 +155,17 @@ extension AnchorHandoff {
 
 //signature bodies
 extension AnchorHandoff {
+	// The v1 bodies. Their digest fields are `TypedDigest`, so this package must be able to
+	// NAME the hash a peer used — which is why v2 exists (see below).
+	//
+	// KNOWN-SWAPPED DISCRIMINATORS, DELIBERATELY FROZEN. `ActiveAgentBody` carries the string
+	// "AnchorHandoff.RetiredAgentBody" and vice versa. This is a labeling bug, not a security
+	// one: domain separation needs the committed strings to be DISTINCT, not correctly named,
+	// and they are distinct — so no signature can be replayed across contexts even when one key
+	// signs both body types across successive rotations. DO NOT "fix" these in place: live
+	// relationships have signatures committed over them, and renaming would silently fail every
+	// verification. They retire with the v1 bodies. The v2 bodies below carry the corrected
+	// names.
 	struct ActiveAnchorBody: LinearEncodedQuad {
 		static let discriminator = "AnchorHandoff.ActiveAnchorBody"
 		let first: String
@@ -166,6 +205,74 @@ extension AnchorHandoff {
 		init(
 			encodedPackage: Data,
 			mlsUpdateDigest: TypedDigest,
+			knownAgent: AgentPublicKey
+		) {
+			self.first = Self.discriminator
+			self.second = encodedPackage
+			self.third = mlsUpdateDigest
+			self.fourth = knownAgent.id
+		}
+	}
+
+	// MARK: - v2 bodies: opaque digests
+	//
+	// Identical in shape to v1, with the digest fields as length-framed `Data`. The point is
+	// ownership: a digest's algorithm is a facet of the MLS backend's cipher suite, so naming it
+	// here (`DigestTypes`) meant a backend could not adopt a new suite until this package
+	// released a matching case. These bodies commit to whatever bytes the caller supplies and
+	// never interpret them — the caller's own self-describing encoding travels INSIDE the value,
+	// so cross-era signatures stay unambiguous without this package knowing the eras.
+	//
+	// This is safe because a verifier never parses a digest off the wire: it rebuilds the body
+	// from a locally derived reference digest and checks the signature against that. Agreement on
+	// the algorithm is enforced where the session is established, not here.
+	//
+	// DISCRIMINATORS: corrected names, `.v2`-suffixed. The suffix is not decoration — the plain
+	// corrected strings are UNAVAILABLE, because v1 has them live on each other's structs (see
+	// the frozen-swap note above). Reusing one would put two different structures under one
+	// committed string across the union of live body types, which is exactly the distinctness
+	// that domain separation rests on. `ActiveAnchorBodyV2` takes the suffix too, though its name
+	// was never swapped: its ENCODING differs from v1's, and keeping discriminator↔encoding 1:1
+	// is what stops this bug class from recurring.
+	struct ActiveAnchorBodyV2: LinearEncodedQuad {
+		static let discriminator = "AnchorHandoff.ActiveAnchorBody.v2"
+		let first: String
+		let second: Content
+		let third: Data  //group context, opaque
+		let fourth: TypedKeyMaterial  //knownAgent
+	}
+
+	struct ActiveAgentBodyV2: LinearEncodedQuintuple {
+		static let discriminator = "AnchorHandoff.ActiveAgentBody.v2"
+		let first: String
+		let second: Content
+		let third: Data  //group context, opaque
+		let fourth: Data  //mls update digest, opaque
+		let fifth: TypedKeyMaterial  //knownAgent
+	}
+
+	struct RetiredAgentBodyV2: LinearEncodedQuad {
+		static let discriminator = "AnchorHandoff.RetiredAgentBody.v2"
+		let first: String
+		let second: Data  //Package.wireformat
+		let third: Data  //mls update digest, opaque
+		let fourth: TypedKeyMaterial  //knownAgent
+
+		init(
+			first: String,
+			second: Data,
+			third: Data,
+			fourth: TypedKeyMaterial
+		) {
+			self.first = first
+			self.second = second
+			self.third = third
+			self.fourth = fourth
+		}
+
+		init(
+			encodedPackage: Data,
+			mlsUpdateDigest: Data,
 			knownAgent: AgentPublicKey
 		) {
 			self.first = Self.discriminator

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -338,6 +338,14 @@ extension PrivateActiveAnchor {
 		groupContext: Data,
 		mlsUpdateDigest: Data,
 	) throws -> AnchorHandoff {
+		// The typed overload guaranteed a well-formed digest structurally; opaque bytes
+		// move that to runtime. Empty is the one unambiguously degenerate value — a
+		// handoff committing to nothing for a slot — and if BOTH ends plumbed empty
+		// (a default-value integration bug), verification would succeed with the MLS
+		// binding silently absent. Refuse at mint so the bug is loud at its source.
+		guard !groupContext.isEmpty, !mlsUpdateDigest.isEmpty else {
+			throw ProtocolError.unexpected("empty digest bytes in opaque handoff body")
+		}
 		let handoffContent = AnchorHandoff.Content(
 			first: .init(
 				publicKey: newAgent.publicKey,

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -318,6 +318,71 @@ extension PrivateActiveAnchor {
 			second: encodedPackage
 		)
 	}
+
+	/// Mint a handoff whose digests are OPAQUE bytes (v2 bodies).
+	///
+	/// Same flow and same wire structure as the typed overload — only the signature bodies
+	/// differ, so `AnchorHandoff` itself is unchanged and the digests never travel in it. Pass
+	/// the MLS backend's own values verbatim (TwoMLSPQ: `proposalContext` and `proposalHash`,
+	/// or a digest from `PQDigest.over(_:)`). They are committed, never parsed, so this package
+	/// no longer needs a case for the backend's hash — the backend can change suites without a
+	/// release here.
+	///
+	/// Verify with `PublicAnchorAgent.verify(anchorHandoff:context:mlsUpdateDigest:)`'s matching
+	/// opaque overload: the two are a pair, and a handoff minted here will NOT verify against
+	/// the typed one (different discriminators, by design).
+	public func createNewAgentHandoff(
+		agentUpdate: AgentUpdate,
+		newAgent: AgentPrivateKey,
+		from retiredAgent: PrivateAnchorAgent,
+		groupContext: Data,
+		mlsUpdateDigest: Data,
+	) throws -> AnchorHandoff {
+		let handoffContent = AnchorHandoff.Content(
+			first: .init(
+				publicKey: newAgent.publicKey,
+				agentUpdate: agentUpdate
+			),
+			second: nil
+		)
+
+		let activeAnchorSignature = try privateKey.signer(
+			try handoffContent
+				.activeAnchorBodyV2(
+					groupContext: groupContext,
+					knownAgent: retiredAgent.publicKey
+				).wireFormat
+		)
+
+		let newAgentSignature = try newAgent.signer(
+			try handoffContent
+				.activeAgentBodyV2(
+					groupContext: groupContext,
+					mlsUpdateDigest: mlsUpdateDigest,
+					knownAgent: retiredAgent.publicKey
+				).wireFormat
+		)
+
+		let package = AnchorHandoff.Package(
+			first: handoffContent,
+			second: activeAnchorSignature,  //active anchor
+			third: newAgentSignature  //new agent
+		)
+
+		let encodedPackage = try package.wireFormat
+		let retiredAgentSignature = try retiredAgent.signer(
+			try AnchorHandoff.RetiredAgentBodyV2(
+				encodedPackage: encodedPackage,
+				mlsUpdateDigest: mlsUpdateDigest,
+				knownAgent: retiredAgent.publicKey
+			).wireFormat
+		)
+
+		return .init(
+			first: retiredAgentSignature,
+			second: encodedPackage
+		)
+	}
 }
 
 extension PrivateActiveAnchor {

--- a/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
@@ -1,0 +1,199 @@
+//
+//  AnchorHandoffV2Tests.swift
+//  CommProtocol
+//
+//  The opaque-digest handoff bodies: a handoff whose `groupContext` and
+//  `mlsUpdateDigest` are bytes this package commits to but never interprets.
+//
+//  Two properties matter here. First, the round trip works on digests whose
+//  algorithm this package cannot name — that is the whole point, since the hash
+//  is a facet of the MLS backend's cipher suite. Second, v1 and v2 are mutually
+//  unverifiable: their discriminators differ, so a signature made under one can
+//  never be replayed as the other.
+//
+
+import AtprotoTypes
+import AtprotoTypesMocks
+import CommProtocolMocks
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+struct AnchorHandoffV2Tests {
+	let alexDID = Atproto.DID.mock()
+	let alexPrivateAnchor: PrivateActiveAnchor
+	let blairDID = Atproto.DID.mock()
+	let blairPrivateAnchor: PrivateActiveAnchor
+
+	init() throws {
+		alexPrivateAnchor = .create(for: alexDID)
+		blairPrivateAnchor = .create(for: blairDID)
+	}
+
+	/// Digest bytes in a shape this package has no case for: tag 0x7F is not a
+	/// `DigestTypes` value, so a `TypedDigest` could not represent this at all.
+	/// The v2 bodies must carry it regardless — that is the contract.
+	private func opaqueDigest(_ seed: UInt8) -> Data {
+		Data([0x7F]) + Data(repeating: seed, count: 48)
+	}
+
+	/// Stand up a verified Alex→Blair anchor exchange and return the pieces a
+	/// handoff needs.
+	private func exchange() throws -> (
+		alexAgent: PrivateAnchorAgent, verifiedByBlair: AnchorHello.Verified
+	) {
+		let alexAgent = alexPrivateAnchor.createHelloAgent()
+		let hello = try alexPrivateAnchor.generateHello(
+			helloAgent: alexAgent,
+			agentVersion: .mock(),
+			mlsKeyPackages: ["mock".utf8Data],
+			policy: .closed
+		)
+		let verified = try alexPrivateAnchor.publicKey
+			.verify(hello: hello, for: .init(anchorTo: alexDID))
+		return (alexAgent, verified)
+	}
+
+	@Test func opaqueHandoffRoundTrips() throws {
+		let (alexAgent, verified) = try exchange()
+		let newAgent = AgentPrivateKey()
+		let context = opaqueDigest(0xA1)
+		let updateDigest = opaqueDigest(0xB2)
+
+		let handoff = try alexPrivateAnchor.createNewAgentHandoff(
+			agentUpdate: .mock(),
+			newAgent: newAgent,
+			from: alexAgent,
+			groupContext: context,
+			mlsUpdateDigest: updateDigest
+		)
+
+		let result = try verified.agent.verify(
+			anchorHandoff: handoff,
+			context: context,
+			mlsUpdateDigest: updateDigest
+		)
+		#expect(result.newAnchor == false)
+		#expect(result.agent.agentKey == newAgent.publicKey)
+	}
+
+	/// The verifier supplies its OWN reference digests — nothing is read out of
+	/// the handoff — so the signature check is what compares them.
+	@Test func wrongReferenceDigestsFailVerification() throws {
+		let (alexAgent, verified) = try exchange()
+		let newAgent = AgentPrivateKey()
+		let context = opaqueDigest(0xA1)
+		let updateDigest = opaqueDigest(0xB2)
+
+		let handoff = try alexPrivateAnchor.createNewAgentHandoff(
+			agentUpdate: .mock(),
+			newAgent: newAgent,
+			from: alexAgent,
+			groupContext: context,
+			mlsUpdateDigest: updateDigest
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try verified.agent.verify(
+				anchorHandoff: handoff,
+				context: self.opaqueDigest(0xFF),
+				mlsUpdateDigest: updateDigest
+			)
+		}
+		#expect(throws: (any Error).self) {
+			_ = try verified.agent.verify(
+				anchorHandoff: handoff,
+				context: context,
+				mlsUpdateDigest: self.opaqueDigest(0xFF)
+			)
+		}
+	}
+
+	/// Domain separation across the two body generations: a v2 handoff must not
+	/// verify as v1 even when the digest BYTES are identical, because the
+	/// discriminators differ. (`TypedDigest.wireFormat` is exactly the bytes the
+	/// opaque form carries, so this feeds both paths the same value — the only
+	/// thing distinguishing them is the committed discriminator.)
+	@Test func v2HandoffDoesNotVerifyAsV1() throws {
+		let (alexAgent, verified) = try exchange()
+		let newAgent = AgentPrivateKey()
+		let typedContext = try TypedDigest.mock()
+		let typedUpdate = try TypedDigest.mock()
+
+		let v2Handoff = try alexPrivateAnchor.createNewAgentHandoff(
+			agentUpdate: .mock(),
+			newAgent: newAgent,
+			from: alexAgent,
+			groupContext: typedContext.wireFormat,
+			mlsUpdateDigest: typedUpdate.wireFormat
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try verified.agent.verify(
+				anchorHandoff: v2Handoff,
+				context: typedContext,
+				mlsUpdateDigest: typedUpdate
+			)
+		}
+	}
+
+	/// And the converse.
+	@Test func v1HandoffDoesNotVerifyAsV2() throws {
+		let (alexAgent, verified) = try exchange()
+		let newAgent = AgentPrivateKey()
+		let typedContext = try TypedDigest.mock()
+		let typedUpdate = try TypedDigest.mock()
+
+		let v1Handoff = try alexPrivateAnchor.createNewAgentHandoff(
+			agentUpdate: .mock(),
+			newAgent: newAgent,
+			from: alexAgent,
+			groupContext: typedContext,
+			mlsUpdateDigest: typedUpdate
+		)
+
+		#expect(throws: (any Error).self) {
+			_ = try verified.agent.verify(
+				anchorHandoff: v1Handoff,
+				context: typedContext.wireFormat,
+				mlsUpdateDigest: typedUpdate.wireFormat
+			)
+		}
+	}
+
+	/// The regression guard for the reason `.v2` is suffixed at all.
+	///
+	/// v1's `ActiveAgentBody` and `RetiredAgentBody` carry each OTHER's names — a
+	/// frozen labeling bug (see the note in AnchorHandoff.swift). Domain separation
+	/// depends on the committed strings being DISTINCT, not correctly named, so the
+	/// swap is harmless; but it means the plain corrected names are occupied, which
+	/// is why v2 cannot simply take them. This asserts the property that actually
+	/// matters across the union of live body types.
+	@Test func everyLiveDiscriminatorIsDistinct() {
+		let all = [
+			AnchorHandoff.ActiveAnchorBody.discriminator,
+			AnchorHandoff.ActiveAgentBody.discriminator,
+			AnchorHandoff.RetiredAgentBody.discriminator,
+			AnchorHandoff.ActiveAnchorBodyV2.discriminator,
+			AnchorHandoff.ActiveAgentBodyV2.discriminator,
+			AnchorHandoff.RetiredAgentBodyV2.discriminator,
+		]
+		#expect(Set(all).count == all.count, "handoff discriminators must be pairwise distinct")
+	}
+
+	/// Pins the frozen swap so nobody "corrects" it in place and silently breaks
+	/// every live relationship's handoff verification.
+	@Test func v1SwapStaysFrozenAndV2IsCorrect() {
+		#expect(AnchorHandoff.ActiveAgentBody.discriminator == "AnchorHandoff.RetiredAgentBody")
+		#expect(AnchorHandoff.RetiredAgentBody.discriminator == "AnchorHandoff.ActiveAgentBody")
+
+		#expect(
+			AnchorHandoff.ActiveAnchorBodyV2.discriminator == "AnchorHandoff.ActiveAnchorBody.v2")
+		#expect(
+			AnchorHandoff.ActiveAgentBodyV2.discriminator == "AnchorHandoff.ActiveAgentBody.v2")
+		#expect(
+			AnchorHandoff.RetiredAgentBodyV2.discriminator == "AnchorHandoff.RetiredAgentBody.v2")
+	}
+}

--- a/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
@@ -163,6 +163,57 @@ struct AnchorHandoffV2Tests {
 		}
 	}
 
+	/// The typed overload guaranteed digest well-formedness structurally; the opaque
+	/// one moves that to runtime, and empty is the one degenerate value both ends
+	/// could plumb symmetrically (a default-value bug) — which would verify with the
+	/// MLS binding silently absent. Both doors refuse it.
+	@Test func emptyDigestBytesAreRefused() throws {
+		let (alexAgent, verified) = try exchange()
+		let newAgent = AgentPrivateKey()
+		let real = opaqueDigest(0xA1)
+
+		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+			_ = try self.alexPrivateAnchor.createNewAgentHandoff(
+				agentUpdate: .mock(),
+				newAgent: newAgent,
+				from: alexAgent,
+				groupContext: Data(),
+				mlsUpdateDigest: real
+			)
+		}
+		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+			_ = try self.alexPrivateAnchor.createNewAgentHandoff(
+				agentUpdate: .mock(),
+				newAgent: newAgent,
+				from: alexAgent,
+				groupContext: real,
+				mlsUpdateDigest: Data()
+			)
+		}
+
+		let handoff = try alexPrivateAnchor.createNewAgentHandoff(
+			agentUpdate: .mock(),
+			newAgent: newAgent,
+			from: alexAgent,
+			groupContext: real,
+			mlsUpdateDigest: real
+		)
+		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+			_ = try verified.agent.verify(
+				anchorHandoff: handoff,
+				context: Data(),
+				mlsUpdateDigest: real
+			)
+		}
+		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+			_ = try verified.agent.verify(
+				anchorHandoff: handoff,
+				context: real,
+				mlsUpdateDigest: Data()
+			)
+		}
+	}
+
 	/// The regression guard for the reason `.v2` is suffixed at all.
 	///
 	/// v1's `ActiveAgentBody` and `RetiredAgentBody` carry each OTHER's names — a


### PR DESCRIPTION
`createNewAgentHandoff` and `PublicAnchorAgent.verify(anchorHandoff:…)` gain overloads taking `groupContext`/`mlsUpdateDigest` as `Data`, backed by v2 signature bodies that commit to those bytes as length-framed values and never interpret them. The motivation is ownership: a digest's algorithm is a facet of the MLS backend's cipher suite, so requiring a `TypedDigest` meant the backend could not adopt a new suite until this package shipped a matching `DigestTypes` case — a release dependency pointing the wrong way. This is safe because a verifier never parses a digest out of a handoff; it rebuilds the body from its own locally derived reference digest and checks the signature against that, so agreement on the algorithm is enforced where the session is established rather than here.

Purely additive. The typed overloads and the v1 bodies are untouched, so every already-issued handoff keeps verifying and nothing needs to re-pair — which is why this is v2-alongside rather than a replacement: classical relationships are live.

**The discriminator fix you were looking for.** v1's `ActiveAgentBody` and `RetiredAgentBody` carry each other's names. It's a labeling bug rather than a security one — domain separation needs the committed strings to be *distinct*, not correctly named, and they are, so nothing can be replayed across contexts. But it's a real landmine for anyone writing a spec or a second implementation from the names. It is now frozen and commented (renaming in place would silently fail verification for every live relationship), and v2 carries the corrected names. They're `.v2`-suffixed because the plain corrected strings are *unavailable* — v1 has them live on the opposite structs, so reusing one would put two different structures under a single committed string. `ActiveAnchorBodyV2` takes the suffix too, though its name was never swapped, to keep discriminator↔encoding strictly 1:1.

Tests: 6 new, full suite 118 green. The round trip runs on a digest tagged `0x7F` — a value `TypedDigest` cannot represent at all — which is the property the change exists for. v1↔v2 non-verification is pinned in both directions, and one test asserts all six discriminators are pairwise distinct while another pins the frozen swap so nobody "corrects" it later.

Adoption is not urgent: the app can keep calling the typed overloads by lifting the backend's bytes with `TypedDigest(wireFormat:)`, which is byte-identical. Moving to these overloads is what removes the last cross-repo release coupling, and it costs a PQ re-pairing whenever you choose to do it.