### PR TITLE
Add changeset for mailbox-grant-wire-types

### DIFF
--- a/.changeset/mailbox-grant-wire-types.md
+++ b/.changeset/mailbox-grant-wire-types.md
@@ -1,0 +1,15 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+Add mailbox-v2 wire types (GER-1965/1966/1967): `swift-cbor` pinned at the same
+revision as CoreAppLogic, a `DeterministicCbor` seam, and `MailboxGrant`
+(`{authKey, serviceHost, expiration}`) with `address`/`putTag` HMAC-SHA256
+derivation, cross-validated against germ-service's test vectors. A
+`ProtocolAddress <-> MailboxGrant` bridge lets a grant ride the existing
+`identifier` field on the wire-frozen PQ establishment surfaces (an authKey's
+32 decoded bytes never collide with a legacy `crypto.randomUUID()` address's
+27) with zero arity change. `AgentUpdateV2` (grants only) rides a new
+`CommProposal` tag, emitted only to peers observed >= `mailboxGrantVersion`
+(2.4.0) — existing proposal tags and the classical `AgentUpdate`/
+`ProtocolAddress` wire format are unchanged (fixture-pinned).


### PR DESCRIPTION
PR #44 (GER-1965/1966/1967) merged without a changeset — the push carrying it stalled and the merge went through before it landed. This adds it retroactively so the next release picks up a minor bump for the mailbox-grant wire types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)