### PR TITLE
Validate agentUpdateV2 on the anchor path; fix mailboxGrantVersion threshold

### DIFF
--- a/.changeset/mailbox-grant-anchor-tag6.md
+++ b/.changeset/mailbox-grant-anchor-tag6.md
@@ -1,0 +1,12 @@
+---
+"@germ-network/autonomous-comm-protocol": minor
+---
+
+`ValidatedForAnchor` gains an `.agentUpdateV2` case (`CommProposal`'s tag 6 was
+previously unhandled on the anchor path — `default: throw .unsupported`), mirroring
+the existing card-side validation. `mailboxGrantVersion` moves `2.4.0` → `3.1.0`:
+the original threshold assumed nothing had ever stamped a version at or above it
+(the property that made `pqCapableVersion` = 2.3.0 sound), but
+`pqDomainSeparationVersion` = 3.0.0 is already stamped by every PQ connection, so a
+2.4.0 gate would have let an old PQ build believe it could parse tag 6 and then drop
+the message. 3.1.0 clears every currently-stamped tier.

--- a/.changeset/mailbox-grant-anchor-tag6.md
+++ b/.changeset/mailbox-grant-anchor-tag6.md
@@ -10,3 +10,10 @@ the original threshold assumed nothing had ever stamped a version at or above it
 `pqDomainSeparationVersion` = 3.0.0 is already stamped by every PQ connection, so a
 2.4.0 gate would have let an old PQ build believe it could parse tag 6 and then drop
 the message. 3.1.0 clears every currently-stamped tier.
+
+`AgentUpdateV2.formatForSigning` now leads with a case discriminator
+(`"CommProposal.agentUpdateV2"`): a proposal's tag byte is not covered by its
+payload's signature, and while tags 1–5 shipped with frozen preimages (kept apart
+by structural parse incompatibility alone), tag 6 has never shipped — so it gets
+cryptographic case binding from birth, free. Wire bytes are unchanged; only the
+signed preimage moves.

--- a/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
+++ b/Sources/CommProtocol/IdentityExchange/IdentityFollowup.swift
@@ -78,24 +78,41 @@ extension AgentUpdate {
 
 	///The agent version at (and above) which an agent is emitted `.agentUpdateV2`
 	///`CommProposal`s carrying ``MailboxGrant``s instead of legacy
-	///``ProtocolAddress``es — next in line after ``pqCapableVersion`` = 2.3.0
-	///(docs/attachment-mailbox-delivery.md, "Wire types").
+	///``ProtocolAddress``es.
+	///
+	///**Corrected from an original 2.4.0** (docs/attachment-mailbox-delivery.md,
+	///"Wire types" — "next in line after `pqCapableVersion` = 2.3.0"). That
+	///reasoning held for 2.3.0 because nothing had ever stamped a version at or
+	///above it; it does not hold here, because ``pqDomainSeparationVersion`` = 3.0.0
+	///is *already stamped* by every PQ connection. A capability tier only proves
+	///"the peer's CommProtocol has the parser" if it exceeds every version any
+	///shipped build has ever advertised — so the tier must clear the highest
+	///existing stamp, not just the previous tier. 3.1.0 clears
+	///``pqDomainSeparationVersion`` with room, and gating stays PQ-only (see
+	///``supportsMailboxGrants``) so no classical connection ever needs to cross
+	///``pqCapableVersion``/``pqDomainSeparationVersion`` to reach it.
 	///
 	///Below this, an agent keeps receiving the classic triple — a legacy
 	///``ProtocolAddress`` list — byte-for-byte unchanged; nothing about its
-	///wire shape moves. `public` so the app imports the same constant as the
-	///single source of truth for the emission gate, which lives there (see
-	///``supportsMailboxGrants``).
+	///wire shape moves. A ``MailboxGrant`` can still ride that triple today via
+	///the ``ProtocolAddress/mailboxGrant`` bridge, ungated — this constant only
+	///gates the first-class `.agentUpdateV2` carriage. `public` so the app
+	///imports the same constant as the single source of truth for the emission
+	///gate, which lives there (see ``supportsMailboxGrants``).
 	public static let mailboxGrantVersion = SemanticVersion(
-		major: 2,
-		minor: 4,
+		major: 3,
+		minor: 1,
 		patch: 0
 	)
 
 	///Whether this agent is emitted `.agentUpdateV2` proposals, per
-	///``mailboxGrantVersion``. Tracking *which* peer has been observed at or
-	///above this threshold — and so deciding when to actually emit one — is
-	///an app-layer concern, the same split as ``isPQCapable``.
+	///``mailboxGrantVersion``. Because the threshold sits above
+	///``pqDomainSeparationVersion``, this is only ever true on a PQ connection —
+	///the app scopes emission to PQ sessions accordingly. Tracking *which* peer
+	///has been observed at or above this threshold (a ratcheted per-agent
+	///maximum, since a later message must not un-observe an earlier one) — and
+	///so deciding when to actually emit one — is an app-layer concern, the same
+	///split as ``isPQCapable``.
 	public var supportsMailboxGrants: Bool {
 		version >= Self.mailboxGrantVersion
 	}

--- a/Sources/CommProtocol/IdentityUpdate/AgentUpdateV2.swift
+++ b/Sources/CommProtocol/IdentityUpdate/AgentUpdateV2.swift
@@ -28,14 +28,25 @@ public struct AgentUpdateV2: Sendable, Equatable {
         self.grants = grants
     }
 
+    ///The signing-body case discriminator. A `CommProposal`'s tag byte is not
+    ///covered by its payload's signature — for tags 1–5 (shipped, preimages
+    ///frozen) the cases are kept apart only by structural parse
+    ///incompatibility, the same property `AnchorHandoff`'s V2 bodies fixed
+    ///with fresh discriminator strings. This case has never shipped, so it
+    ///gets the discriminator from birth: a signature over an `AgentUpdateV2`
+    ///can never verify as any other case's content, independent of how the
+    ///byte shapes evolve. Cases from tag 6 onward should do the same.
+    static let signingDiscriminator = Data("CommProposal.agentUpdateV2".utf8)
+
     ///Mirrors `AgentUpdate.formatForSigning(updateMessage:context:)` — the
     ///signature binds the update to the MLS proposal (`updateMessage`) and
-    ///the session `context`.
+    ///the session `context` — prefixed with ``signingDiscriminator`` to bind
+    ///it to this `CommProposal` case as well.
     func formatForSigning(
         updateMessage: Data,
         context: TypedDigest
     ) throws -> Data {
-        try wireFormat + updateMessage + context.wireFormat
+        try Self.signingDiscriminator + wireFormat + updateMessage + context.wireFormat
     }
 }
 

--- a/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
+++ b/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
@@ -306,6 +306,7 @@ extension CommProposal {
 	public enum ValidatedForAnchor: Sendable {
 		case sameAgent(AgentUpdate, IdentityMutableData?)
 		case agentHandoff(AnchorHandoff.Verified)
+		case agentUpdateV2(AgentUpdateV2, IdentityMutableData?)
 	}
 
 	public func validate(
@@ -337,6 +338,22 @@ extension CommProposal {
 					context: context,
 					mlsUpdateDigest: mlsUpdateDigest
 				)
+			)
+		case .agentUpdateV2(let signedAgentUpdateV2, let signedMutable):
+			let verifiedMutable: IdentityMutableData? = try {
+				guard let signedMutable else { return nil }
+				return try knownAnchor.anchor.publicKey
+					.verify(signedMutable: signedMutable)
+			}()
+
+			return .agentUpdateV2(
+				try knownAnchor.agentKey
+					.validate(
+						signedAgentUpdateV2: signedAgentUpdateV2,
+						for: mlsUpdateDigest.wireFormat,
+						context: context
+					),
+				verifiedMutable
 			)
 		default:
 			throw ProtocolError.unsupported

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
@@ -224,6 +224,31 @@ struct AgentUpdateV2Tests {
         }
     }
 
+    // MARK: - Signing-body case discriminator
+
+    /// The tag byte of a `CommProposal` is not covered by its payload's
+    /// signature, so `.agentUpdateV2` domain-separates its signing body with a
+    /// case discriminator (unlike tags 1–5, whose preimages shipped frozen).
+    /// Pins the exact preimage layout: discriminator ‖ wireFormat ‖
+    /// updateMessage ‖ context — removing or reordering any element must fail
+    /// here, not in production signature mismatches.
+    @Test func testFormatForSigningCarriesCaseDiscriminator() throws {
+        let update = AgentUpdateV2.mock()
+        let message = Data([0x0A, 0x0B])
+        let context = try TypedDigest.mock()
+
+        let preimage = try update.formatForSigning(
+            updateMessage: message,
+            context: context
+        )
+        let expected =
+            try Data("CommProposal.agentUpdateV2".utf8)
+            + update.wireFormat
+            + message
+            + context.wireFormat
+        #expect(preimage == expected)
+    }
+
     // MARK: - ValidatedForAnchor.agentUpdateV2 (Part 0: PersistedRatchet/AppSession
     // is the anchor path — .sameAgent's card-side sibling had no anchor-side
     // handling at all before this, tag 6 fell into `default: throw unsupported`)

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
@@ -3,6 +3,8 @@
 //  CommProtocol
 //
 
+import AtprotoTypes
+import AtprotoTypesMocks
 import CommProtocolMocks
 import CryptoKit
 import Foundation
@@ -222,11 +224,88 @@ struct AgentUpdateV2Tests {
         }
     }
 
+    // MARK: - ValidatedForAnchor.agentUpdateV2 (Part 0: PersistedRatchet/AppSession
+    // is the anchor path — .sameAgent's card-side sibling had no anchor-side
+    // handling at all before this, tag 6 fell into `default: throw unsupported`)
+
+    @Test func testAgentUpdateV2ProposalAnchorValidate() throws {
+        let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+        let invitationAgent = acceptorAnchor.createHelloAgent()
+        let knownAnchor = PublicAnchorAgent(
+            anchor: acceptorAnchor.publicAnchor,
+            agentKey: invitationAgent.publicKey
+        )
+        let mlsUpdateDigest = try TypedDigest.mock()
+        let mockContext = try TypedDigest.mock()
+
+        // signedIdentityMutable: nil — the anchor-side signer for
+        // IdentityMutableData is orthogonal to what this test covers (the new
+        // tag-6 branch's AgentUpdateV2 signature verification against the
+        // agent key) and has no established construction pattern in this
+        // test suite; the non-nil arm is exercised card-side already
+        // (testAgentUpdateV2Proposal).
+        let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
+            leafNodeUpdate: mlsUpdateDigest.wireFormat,
+            agentUpdate: .mock(),
+            signedIdentityMutable: nil,
+            context: mockContext
+        )
+        let wireProposal = try proposal.wireFormat
+
+        let validated = try CommProposal.finalParse(wireProposal)
+            .validate(
+                knownAnchor: knownAnchor,
+                context: mockContext,
+                mlsUpdateDigest: mlsUpdateDigest
+            )
+
+        guard case .agentUpdateV2(let agentUpdate, let mutableData) = validated else {
+            Issue.record("expected .agentUpdateV2")
+            return
+        }
+        #expect(!agentUpdate.grants.isEmpty)
+        #expect(mutableData == nil)
+    }
+
+    @Test func testAgentUpdateV2ProposalAnchorValidateRejectsWrongKey() throws {
+        let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+        let invitationAgent = acceptorAnchor.createHelloAgent()
+        let wrongAgent = AgentPrivateKey()
+        let knownAnchor = PublicAnchorAgent(
+            anchor: acceptorAnchor.publicAnchor,
+            // validate against a key the proposal was NOT signed by
+            agentKey: wrongAgent.publicKey
+        )
+        let mlsUpdateDigest = try TypedDigest.mock()
+        let mockContext = try TypedDigest.mock()
+
+        let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
+            leafNodeUpdate: mlsUpdateDigest.wireFormat,
+            agentUpdate: .mock(),
+            signedIdentityMutable: nil,
+            context: mockContext
+        )
+        let wireProposal = try proposal.wireFormat
+
+        #expect(throws: ProtocolError.authenticationError) {
+            let _ = try CommProposal.finalParse(wireProposal)
+                .validate(
+                    knownAnchor: knownAnchor,
+                    context: mockContext,
+                    mlsUpdateDigest: mlsUpdateDigest
+                )
+        }
+    }
+
     // MARK: - mailboxGrantVersion gate
 
     @Test func testSupportsMailboxGrantsBoundary() {
+        // Just below the threshold — deliberately still above
+        // pqDomainSeparationVersion (3.0.0), the case the original 2.4.0
+        // threshold got wrong: a version already stamped by every PQ
+        // connection must NOT pass this gate.
         let below = AgentUpdate(
-            version: SemanticVersion(major: 2, minor: 3, patch: 9999),
+            version: SemanticVersion(major: 3, minor: 0, patch: 9999),
             isAppClip: false,
             addresses: []
         )
@@ -236,7 +315,7 @@ struct AgentUpdateV2Tests {
             addresses: []
         )
         let above = AgentUpdate(
-            version: SemanticVersion(major: 2, minor: 4, patch: 1),
+            version: SemanticVersion(major: 3, minor: 1, patch: 1),
             isAppClip: false,
             addresses: []
         )
@@ -245,9 +324,15 @@ struct AgentUpdateV2Tests {
         #expect(above.supportsMailboxGrants)
     }
 
-    @Test func testMailboxGrantVersionOrdering() {
-        // Sits between the two existing PQ thresholds, per the design doc.
+    /// The soundness property `mailboxGrantVersion`'s doc comment states:
+    /// a capability tier only proves "the peer's CommProtocol has the parser"
+    /// if it exceeds every version any shipped build has ever stamped. This
+    /// is the corrected replacement for a test that once asserted the
+    /// original (unsound) 2.4.0 sat *between* pqCapableVersion and
+    /// pqDomainSeparationVersion — which put it below a version PQ
+    /// connections already stamp.
+    @Test func testMailboxGrantVersionExceedsAllStampedTiers() {
         #expect(AgentUpdate.pqCapableVersion < AgentUpdate.mailboxGrantVersion)
-        #expect(AgentUpdate.mailboxGrantVersion < AgentUpdate.pqDomainSeparationVersion)
+        #expect(AgentUpdate.pqDomainSeparationVersion < AgentUpdate.mailboxGrantVersion)
     }
 }


### PR DESCRIPTION
Two prerequisites for GER-1972 (app-side mailbox v2), found while planning it:

1. **`ValidatedForAnchor` had no `.agentUpdateV2` case.** `ValidatedForCard` already handled tag 6; the anchor path (`PersistedRatchet`/`AppSession`, where GER-1972's staple lives) fell into `default: throw .unsupported`. Added, mirroring the card-side validation exactly — same `AgentPublicKey.validate(signedAgentUpdateV2:...)` already used there.

2. **`mailboxGrantVersion` was unsound.** Shipped at 2.4.0 on the assumption "next tier after `pqCapableVersion` (2.3.0), nothing has stamped past it yet" — the same reasoning that made 2.3.0 work. That assumption silently broke: `pqDomainSeparationVersion` (3.0.0) is stamped by every PQ connection today. An old PQ build would pass a `>= 2.4.0` gate and then drop an unknown tag-6 message on the floor. Moved to 3.1.0, which clears every currently-stamped tier — documented as the actual soundness rule this time (a capability tier must exceed every version any shipped build has ever advertised, not just the previous tier).

151 tests pass, including 2 new anchor-side `.agentUpdateV2` validate tests (happy path + wrong-key rejection) and corrected boundary/ordering tests for the new threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)