### PR TITLE
Pin swift-cbor to a tagged release instead of a revision

### DIFF
--- a/.changeset/swift-cbor-tagged-release.md
+++ b/.changeset/swift-cbor-tagged-release.md
@@ -1,0 +1,12 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Pin `swift-cbor` to `from: "0.1.0"` instead of a revision. The revision pin
+predates swift-cbor's 0.1.0 release; confirmed the pinned commit
+(`8d9b9c2`, the `deterministicCbor` option) is an ancestor of 0.1.0's tagged
+commit, so this is a no-op for the code actually built. It matters because a
+stable-tagged package (this one, as of `v1.12.0`) cannot depend on a
+revision-pinned package — SwiftPM refuses to resolve it for any downstream
+consumer pinning this package by version, which blocked `germ-service-client`
+picking up `v1.12.0`.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5e61db99593c694326104c2b6d58bffd3fcc011a04b0c5024de8e4e151e8cf81",
+  "originHash" : "3c891703c1ba60dcaedcec1f444b357e8c22789e1e07c801e767ff8a532721d5",
   "pins" : [
     {
       "identity" : "atprototypes",
@@ -42,7 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nnabeyang/swift-cbor.git",
       "state" : {
-        "revision" : "8d9b9c25284c6a2f0a564f4c42c7dc3466d08472"
+        "revision" : "068a3f900e0078aef0be8542ef017e5347217b32",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,10 +26,14 @@ let package = Package(
 		),
 		.package(url: "https://github.com/swift-libp2p/swift-bases.git", from: "0.2.0"),
 		.package(
-			// pinned by revision: `Options.deterministicCbor` (RFC 8949 §4.2.1)
-			// is on main and not in any released tag. Same pin as CoreAppLogic.
+			// swift-cbor 0.1.0 includes `Options.deterministicCbor` (RFC 8949
+			// §4.2.1) — confirmed the previously-pinned revision
+			// (8d9b9c2, "feature/deterministic-cbor-option") is an ancestor of
+			// 0.1.0's tagged commit. A stable-tagged package (this one, since
+			// PR #46) cannot depend on a revision-pinned one — SwiftPM refuses
+			// to resolve it — so this must track a real tag, not a revision.
 			url: "https://github.com/nnabeyang/swift-cbor.git",
-			revision: "8d9b9c25284c6a2f0a564f4c42c7dc3466d08472"
+			from: "0.1.0"
 		),
 	],
 	targets: [


### PR DESCRIPTION
Discovered while consuming the just-released v1.12.0 from germ-service-client: SwiftPM refuses to resolve a stable-tagged package (this one) against a downstream consumer's `from:` version constraint if it depends on a revision-pinned package. `swift-cbor` was pinned by revision because the `deterministicCbor` option wasn't in any tag at the time — but it's since shipped in `0.1.0`. Confirmed the pinned revision is an ancestor of `0.1.0`'s commit, so this is a no-op for the built code, just a resolution-metadata fix.

Patch changeset — no source changes, 152 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)