### PR TITLE
Re-base the framing layer's Data slice factories

### DIFF
--- a/.changeset/definedwidth-rebase-startindex.md
+++ b/.changeset/definedwidth-rebase-startindex.md
@@ -1,0 +1,14 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Re-base `DefinedWidthBinary.init(wireFormat:)` so it stores its payload as a
+zero-based `Data` rather than a `suffix(from:)` view. `Data` is its own
+SubSequence, so the old form handed conformers a `checkedData` whose valid range
+began at the caller's `startIndex + 1` — safe for `.first`/`.count`/`for`-in, a
+wrong-window read or a trap for `[0]` or `[0..<n]`. `parse(wireFormat:)` has
+always re-based, so the two construction paths disagreed while nothing in the
+type signalled which one produced a value; every `DataIdentifier`,
+`TypedKeyMaterial`, and `TypedDigest` built via `init(wireFormat:)` carried a
+non-zero `startIndex`. Wire format is unchanged — this only affects the indices
+of the decoded value in memory.

--- a/.changeset/definedwidth-rebase-startindex.md
+++ b/.changeset/definedwidth-rebase-startindex.md
@@ -10,5 +10,10 @@ wrong-window read or a trap for `[0]` or `[0..<n]`. `parse(wireFormat:)` has
 always re-based, so the two construction paths disagreed while nothing in the
 type signalled which one produced a value; every `DataIdentifier`,
 `TypedKeyMaterial`, and `TypedDigest` built via `init(wireFormat:)` carried a
-non-zero `startIndex`. Wire format is unchanged — this only affects the indices
-of the decoded value in memory.
+non-zero `startIndex`. The framing layer's other two slice factories are
+re-based the same way: `DeclaredWidthData.parse` and the `Data` field in
+`OptionalData.parse`, which backs `Data: LinearEncodable`. Every `Data` the
+framing layer hands out is now zero-based, so consumers that index absolutely —
+including ones outside this package — cannot be handed a view they have no way
+to detect. Wire format is unchanged; this only affects the indices of the
+decoded value in memory.

--- a/Sources/CommProtocol/MessageFraming/DeclaredWidth.swift
+++ b/Sources/CommProtocol/MessageFraming/DeclaredWidth.swift
@@ -76,8 +76,11 @@ extension DeclaredWidthData: LinearEncodable {
 			input
 			.suffix(from: input.startIndex + MemoryLayout<UInt16>.size)
 
+		//re-based for the same reason as DefinedWidthBinary.init(wireFormat:):
+		//a parsed body outlives this call, and nothing downstream can tell it
+		//was carved out of the caller's buffer
 		let result = try DeclaredWidthData(
-			body: bodySlice.prefix(bodyWidth)
+			body: Data(bodySlice.prefix(bodyWidth))
 		)
 		return (result, consumeWidth)
 	}

--- a/Sources/CommProtocol/MessageFraming/DefinedWidthBinary.swift
+++ b/Sources/CommProtocol/MessageFraming/DefinedWidthBinary.swift
@@ -42,9 +42,15 @@ extension DefinedWidthBinary {
 		guard wireFormat.count == prefixType.contentByteSize + 1 else {
 			throw .incorrectDataLength
 		}
+		//Re-based, not a suffix view: `suffix(from:)` would hand the conforming
+		//type a Data whose startIndex tracks the caller's buffer, so anything
+		//that later indexed `checkedData` absolutely would read the wrong
+		//window or trap. `parse(wireFormat:)` below has always re-based; these
+		//two construction paths must agree, since callers pick between them
+		//freely and nothing in the type signals which one produced a value.
 		try self.init(
 			prefix: prefixType,
-			checkedData: wireFormat.suffix(from: wireFormat.startIndex + 1)
+			checkedData: Data(wireFormat.suffix(from: wireFormat.startIndex + 1))
 		)
 	}
 

--- a/Sources/CommProtocol/MessageFraming/LinearEncodedData.swift
+++ b/Sources/CommProtocol/MessageFraming/LinearEncodedData.swift
@@ -33,7 +33,9 @@ struct OptionalData: LinearEncodable {
 				throw .unexpectedEOF
 			}
 			let width = Int(UInt8(prefix))
-			let data = slice.prefix(width)
+			//re-based: `prefix` of a suffix keeps the caller's indices, and a
+			//parsed field is handed to consumers that cannot know that
+			let data = Data(slice.prefix(width))
 			return (.init(data: data), width + 1)
 		}
 	}

--- a/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
+++ b/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
@@ -45,6 +45,30 @@ struct DefinedWidthStartIndexTests {
 		#expect(decoded.identifier[0] == original.identifier[0])
 	}
 
+	///The framing layer's other slice factory: a `Data` field parsed out of a
+	///linear frame. These feed header-decrypt call sites that index absolutely.
+	@Test func linearEncodedDataParsesZeroBased() throws {
+		for payload in [Data(0..<24), Data(repeating: 0x11, count: 400)] {
+			let frame = try payload.wireFormat
+			let (parsed, _) = try Data.parse(frame)
+
+			#expect(parsed.startIndex == 0)
+			#expect(parsed == payload)
+			#expect(parsed[0] == payload[0])
+		}
+	}
+
+	///Parsed out of a frame that is itself mid-buffer — the realistic case,
+	///since linear frames are consumed as a running remainder.
+	@Test func linearEncodedDataIsZeroBasedFromAnOffsetFrame() throws {
+		let payload = Data(0..<24)
+		let padded = Data(repeating: 0xEE, count: 5) + (try payload.wireFormat)
+
+		let (parsed, _) = try Data.parse(padded.suffix(from: 5))
+		#expect(parsed.startIndex == 0)
+		#expect(parsed == payload)
+	}
+
 	///Same guarantee for the other widely-used conformer, whose payload feeds
 	///key material rather than an identifier.
 	@Test func typedKeyMaterialIsZeroBasedFromASlice() throws {

--- a/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
+++ b/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
@@ -1,0 +1,59 @@
+//
+//  DefinedWidthStartIndexTests.swift
+//  CommProtocol
+//
+//  Created by Mark Xue on 8/4/26.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import CommProtocol
+
+///`Data` is its own SubSequence, so a value carved out of a larger buffer keeps
+///that buffer's indices. A conforming type that stored such a view would hand
+///every consumer a `checkedData` whose valid range starts past zero — safe for
+///`.first`/`.count`/`for`-in, a trap for `[0]` or `[0..<n]`. Both construction
+///paths must therefore re-base, and they must agree with each other.
+struct DefinedWidthStartIndexTests {
+	@Test func bothConstructionPathsAreZeroBased() throws {
+		let original = DataIdentifier(width: .bits256)
+
+		let viaInit = try DataIdentifier(wireFormat: original.wireFormat)
+		let (viaParse, _) = try DataIdentifier.parse(wireFormat: original.wireFormat)
+
+		#expect(viaInit.identifier.startIndex == 0)
+		#expect(viaParse.identifier.startIndex == 0)
+		#expect(viaInit.identifier == original.identifier)
+		#expect(viaParse.identifier == original.identifier)
+	}
+
+	///The regression proper: decoding out of the middle of a larger buffer is
+	///what makes a non-zero startIndex reachable in the first place.
+	@Test func aWireFormatCarvedFromABufferStillDecodesZeroBased() throws {
+		let original = DataIdentifier(width: .bits256)
+		let padded = Data(repeating: 0xAA, count: 7) + original.wireFormat
+		let embedded = padded.suffix(from: 7)
+
+		#expect(embedded.startIndex == 7)
+
+		let decoded = try DataIdentifier(wireFormat: embedded)
+		#expect(decoded.identifier.startIndex == 0)
+		#expect(decoded.identifier == original.identifier)
+		//the operation that traps on a view
+		#expect(decoded.identifier[0] == original.identifier[0])
+	}
+
+	///Same guarantee for the other widely-used conformer, whose payload feeds
+	///key material rather than an identifier.
+	@Test func typedKeyMaterialIsZeroBasedFromASlice() throws {
+		let key = SymmetricKey(size: .bits256)
+		let original = try TypedKeyMaterial(algorithm: .chaCha20Poly1305, symmetricKey: key)
+		let padded = Data(repeating: 0x55, count: 3) + original.wireFormat
+
+		let decoded = try TypedKeyMaterial(wireFormat: padded.suffix(from: 3))
+		#expect(decoded.keyData.startIndex == 0)
+		#expect(decoded.keyData == original.keyData)
+	}
+}


### PR DESCRIPTION
`Data` is its own SubSequence, so a parsed field carved out of a caller's buffer
keeps that buffer's indices — safe for `.first`/`.count`/`for`-in, a wrong-window
read or a trap for `[0]` or `[0..<n]`. Three places in the framing layer handed
out such views:

- `DefinedWidthBinary.init(wireFormat:)` — this one also disagreed with its own
  sibling `parse(wireFormat:)`, which has always re-based, so the two
  construction paths produced different `startIndex` values while nothing in the
  type says which one built a value. Every `DataIdentifier`, `TypedKeyMaterial`,
  and `TypedDigest` built via `init` carried a non-zero `startIndex`.
- `DeclaredWidthData.parse`
- `OptionalData.parse`, which backs `Data: LinearEncodable`

All three now re-base, so every `Data` the framing layer hands out is zero-based
and no consumer can be given a view it has no way to detect. Wire format is
unchanged; only the decoded value's in-memory indices move.

Found from a live crash in germDM:  A `Data` field parsed out of a linear frame already reaches
`PQCardInvitation.decodeHeader`, one type away from a parser that indexes
absolutely.

## Test notes
Five tests covering both `DefinedWidthBinary` paths and the linear `Data` parse,
including frames carved mid-buffer. All fail without the change (one traps on the
`[0]` line). Full suite passes, 157 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)