### PR TITLE
Give each platform its own CI workflow and badge

### DIFF
--- a/.changeset/lucky-pans-smile.md
+++ b/.changeset/lucky-pans-smile.md
@@ -1,0 +1,6 @@
+---
+---
+
+CI and README only — one workflow per platform, each named for the platform it
+covers, and a badge row saying which three CI actually proves. No package
+change, so no release.

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -1,0 +1,28 @@
+name: Android
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".editorconfig"
+      - ".spi.yml"
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-android:
+    name: Test Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@v2
+        with:
+          swift-version: "6.3"

--- a/.github/workflows/ci-apple.yml
+++ b/.github/workflows/ci-apple.yml
@@ -1,17 +1,15 @@
-name: CI
+name: Apple
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
     paths-ignore:
       - 'README.md'
       - 'CODE_OF_CONDUCT.md'
       - '.editorconfig'
       - '.spi.yml'
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,34 @@
+name: Linux
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "README.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".editorconfig"
+      - ".spi.yml"
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux_test:
+    name: Test Linux
+    runs-on: ubuntu-latest
+    container:
+      image: swift:${{matrix.swift-version}}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        swift-version:
+          - "6.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - run: swift --version
+      - name: Test
+        run: swift test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Communicator Protocol
+[![Apple](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-apple.yml/badge.svg)](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-apple.yml)
+[![Linux](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-linux.yml)
+[![Android](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-android.yml/badge.svg)](https://github.com/germ-network/autonomous-comm-protocol/actions/workflows/ci-android.yml)
 A protocol for creating and exchanging identities to create dynamic end to end encrypted channels between user-defined identities
 
 Learn more in the [explainer](https://www.germnetwork.com/blog/autonomous-communicator-ac-protocol)


### PR DESCRIPTION
Splits `ci.yml` into `ci-apple.yml` / `ci-linux.yml` / `ci-android.yml`, each
`name:`d for its platform, and puts all three badges in the README. No source
change, no release.

**Stacked on #56** — the Linux and Android legs cannot pass without the
swift-crypto port. Rebase onto `main` once that merges.

### Why

GitHub's Actions status badges are workflow-scoped — there is no per-job filter,
so a badge can only ever be as specific as the workflow it points at. Same
pattern as germ-network/AtprotoTypes#53, with its post-review refinements
baked in from the start:

- push CI runs only on `main`; PRs are covered by unfiltered `pull_request`
  events (so stacked PRs like this one still get CI), one run per commit.
- Linux pins `swift:6.2` — the effective toolchain floor: this package's
  manifest is tools-version 6.0, but the AtprotoTypes dependency's manifest is
  6.2, and resolving it needs a toolchain that can parse it.
- Android pins toolchain 6.3 via skiptools/swift-android-action, matching the
  fleet.

### Notes

- `main` has no branch protection; nothing references the old workflow name.
- Badges read "no status" until this merges and `main` gets its first run.
  Self-healing.
- Empty changeset — CI and README only.

Part of GER-2175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
