### PR TITLE
Adopt swift-bases 0.3.0's throwing Data(base64URLEncoded:)

### DIFF
--- a/.changeset/tame-wombats-adopt.md
+++ b/.changeset/tame-wombats-adopt.md
@@ -1,0 +1,5 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Adopt swift-bases 0.3.0's throwing `Data(base64URLEncoded:)` in `MailboxGrant.mailboxGrant`. No behavior change — a decode failure still yields `nil` from that computed property — but this was a source break for anyone whose resolved dependency graph floats past swift-bases 0.2.1.

--- a/Sources/CommProtocol/Objects/MailboxGrant.swift
+++ b/Sources/CommProtocol/Objects/MailboxGrant.swift
@@ -151,7 +151,7 @@ extension ProtocolAddress {
     /// a grant-bearing `ProtocolAddress`; nothing else should hand-construct
     /// one with a base64url identifier.
     public var mailboxGrant: MailboxGrant? {
-        guard let keyData = Data(base64URLEncoded: identifier),
+        guard let keyData = try? Data(base64URLEncoded: identifier),
             keyData.count == TypedKeyMaterial.Algorithms.hmacSha256.contentByteSize,
             let authKey = try? TypedKeyMaterial(
                 algorithm: .hmacSha256,

--- a/Tests/CommProtocolTests/CommProtocolTests.swift
+++ b/Tests/CommProtocolTests/CommProtocolTests.swift
@@ -54,7 +54,7 @@ struct APITests {
 		#expect(resourceURL?.path() == "/api/card/fetch/" + resource.identifier)
 
 		let keyFragment = try #require(resourceURL?.fragment())
-		let keyData = try #require(Data(base64URLEncoded: keyFragment))
+		let keyData = try #require(try? Data(base64URLEncoded: keyFragment))
 		#expect(SymmetricKey(data: keyData) == resource.symmetricKey)
 	}
 


### PR DESCRIPTION
`swift-bases` 0.3.0 (the commit right after 0.2.1 — this library has almost no history) changed `Data.init(base64URLEncoded:)` from a failable initializer (`Data?`) to a throwing one. `MailboxGrant.swift:154` used it as `guard let keyData = Data(base64URLEncoded: identifier)`, which only type-checks against the old failable form — so this silently breaks for anyone whose resolved graph floats past 0.2.1, independent of anything in this repo.

`try?` is the correct, version-agnostic adoption: it collapses a throwing call to `Optional` the same way it's a harmless (if slightly redundant) no-op wrapping an already-failable one, so the fix is correct whichever `swift-bases` version actually resolves. No behavior change — a decode failure still yields `nil` from `mailboxGrant`.

Found while resolving `AtprotoGerm`'s dependency graph against a current `swift-bases` for germ-network/germDM-ios-refresh#703.

## Testing

Full suite: 157 tests in 34 suites pass, including `MailboxGrantTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)