### PR TITLE
Require swift-bases 0.3.0 in the manifest, not just the lockfile

### DIFF
--- a/.changeset/olive-pandas-require.md
+++ b/.changeset/olive-pandas-require.md
@@ -1,0 +1,5 @@
+---
+"@germ-network/comm-protocol": patch
+---
+
+Require swift-bases 0.3.0 in the manifest. `MailboxGrant` is written against 0.3.0's throwing `Data(base64URLEncoded:)`, but `Package.swift` still permitted 0.2.x — and consumers resolve from the manifest, not this package's `Package.resolved`, so the previous change expressed the adoption only locally.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c891703c1ba60dcaedcec1f444b357e8c22789e1e07c801e767ff8a532721d5",
+  "originHash" : "3f35c2f7e67b8815793342e45cf4229ec6dddc8cb5c25fde954c8f959d9cf2cc",
   "pins" : [
     {
       "identity" : "atprototypes",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-libp2p/swift-bases.git",
       "state" : {
-        "revision" : "96615d4b582f9f6536d8278304ce2a64c8e5288a",
-        "version" : "0.2.0"
+        "revision" : "f6f3ddc88aef6fd39494a35a7e95cd93c1a63e79",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,10 @@ let package = Package(
 			url: "https://github.com/germ-network/GermConvenience.git",
 			from: "0.2.2"
 		),
-		.package(url: "https://github.com/swift-libp2p/swift-bases.git", from: "0.2.0"),
+		//0.3.0 made Data(base64URLEncoded:) throwing rather than failable, and
+		//MailboxGrant is written against that. Consumers ignore this package's
+		//Package.resolved, so the floor has to be stated here.
+		.package(url: "https://github.com/swift-libp2p/swift-bases.git", from: "0.3.0"),
 		.package(
 			// swift-cbor 0.1.0 includes `Options.deterministicCbor` (RFC 8949
 			// §4.2.1) — confirmed the previously-pinned revision


### PR DESCRIPTION
## Summary

#53 adopted 0.3.0's throwing `Data(base64URLEncoded:)` in `MailboxGrant` and bumped `Package.resolved`, but left `Package.swift` at `from: "0.2.0"`.

That distinction matters: **consumers ignore this package's `Package.resolved`** and resolve from the manifest alone. So the adoption bound nothing downstream — it only described what this repo happened to resolve locally.

The consequence is concrete. `germ-service-client` depends on a released acp; once its own graph moves swift-bases to 0.3.0, the resolved `CommProtocol` fails to compile:

```
.../CommProtocol/Objects/MailboxGrant.swift:154:15: error: initializer for
conditional binding must have Optional type, not 'Data'
```

Stating the floor here is what makes #53's fix actually reachable by dependents.

## Test plan
- [x] `swift build` clean
- [x] `swift test`: 157 tests in 34 suites passing

## Note on sequencing

This wants a release. The fix from #53 is on `main` but the latest tag is **v1.12.2 (Aug 5)**, which predates it — so no released acp yet carries either change, and [germ-service-client#31](https://github.com/germ-network/germ-service-client/pull/31) is blocked until one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)