### PR TITLE
Import Crypto from swift-crypto instead of CryptoKit

### DIFF
--- a/.changeset/brave-otters-travel.md
+++ b/.changeset/brave-otters-travel.md
@@ -1,0 +1,8 @@
+---
+"@germ-network/autonomous-comm-protocol": patch
+---
+
+Depend on swift-crypto and import Crypto instead of CryptoKit, so the package
+builds on Linux and Android. On Apple platforms swift-crypto delegates to
+CryptoKit, so behavior is unchanged. Raises the AtprotoTypes floor to 0.5.0,
+the first release that builds on those platforms.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3f35c2f7e67b8815793342e45cf4229ec6dddc8cb5c25fde954c8f959d9cf2cc",
+  "originHash" : "dcfc9acdec83fb15c6530a24a4eace01fc241c0e15dd951df696097e70885df9",
   "pins" : [
     {
       "identity" : "atprototypes",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/germ-network/AtprotoTypes.git",
       "state" : {
-        "revision" : "12207f3ede15d1a4e6997a0bac6b3718400d2a5f",
-        "version" : "0.4.5"
+        "revision" : "c953ca95e0436808db515fa0d910152880c96500",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,9 @@ let package = Package(
 	],
 	dependencies: [
 		.package(
+			//0.5.0 is the first release that builds for Linux and Android
 			url: "https://github.com/germ-network/AtprotoTypes.git",
-			from: "0.4.5"
+			from: "0.5.0"
 		),
 		.package(
 			url: "https://github.com/germ-network/GermConvenience.git",
@@ -28,6 +29,9 @@ let package = Package(
 		//MailboxGrant is written against that. Consumers ignore this package's
 		//Package.resolved, so the floor has to be stated here.
 		.package(url: "https://github.com/swift-libp2p/swift-bases.git", from: "0.3.0"),
+		.package(
+			url: "https://github.com/apple/swift-crypto.git",
+			.upToNextMajor(from: "4.2.0")),
 		.package(
 			// swift-cbor 0.1.0 includes `Options.deterministicCbor` (RFC 8949
 			// §4.2.1) — confirmed the previously-pinned revision
@@ -48,17 +52,25 @@ let package = Package(
 				.product(name: "AtprotoTypes", package: "AtprotoTypes"),
 				.product(name: "AtprotoTypesMocks", package: "AtprotoTypes"),
 				.product(name: "Base64", package: "swift-bases"),
+				.product(name: "Crypto", package: "swift-crypto"),
 				"GermConvenience",
 				.product(name: "SwiftCbor", package: "swift-cbor"),
 			]
 		),
 		.target(
 			name: "CommProtocolMocks",
-			dependencies: ["CommProtocol"]
+			dependencies: [
+				"CommProtocol",
+				.product(name: "Crypto", package: "swift-crypto"),
+			]
 		),
 		.testTarget(
 			name: "CommProtocolTests",
-			dependencies: ["CommProtocol", "CommProtocolMocks"]
+			dependencies: [
+				"CommProtocol",
+				"CommProtocolMocks",
+				.product(name: "Crypto", package: "swift-crypto"),
+			]
 		),
 	]
 )

--- a/Sources/CommProtocol/Anchors/AnchorKey.swift
+++ b/Sources/CommProtocol/Anchors/AnchorKey.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 3/6/25.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 //taking an approach different from Identity and Agent where we make the

--- a/Sources/CommProtocol/Anchors/DependentIdentity.swift
+++ b/Sources/CommProtocol/Anchors/DependentIdentity.swift
@@ -6,7 +6,7 @@
 //
 
 import AtprotoTypes
-import CryptoKit
+import Crypto
 import Foundation
 
 public protocol AnchorTo: Sendable {

--- a/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
+++ b/Sources/CommProtocol/Anchors/PrivateActiveAnchor.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 4/24/25.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 public struct PrivateActiveAnchor: Sendable {

--- a/Sources/CommProtocol/Convenience.swift
+++ b/Sources/CommProtocol/Convenience.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 6/23/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 extension Digest {

--- a/Sources/CommProtocol/CoreIdentity.swift
+++ b/Sources/CommProtocol/CoreIdentity.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 6/15/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///CoreIdentity is an identity key that asserts a user-facing representation:
@@ -79,7 +79,9 @@ public enum ImageType: UInt8, Sendable {
 			return .jpegXL
 		}
 		//JXL ISOBMFF container: 00 00 00 0C 4A 58 4C 20 0D 0A 87 0A
-		if data.starts(with: [0, 0, 0, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A]) {
+		if data.starts(with: [
+			0, 0, 0, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A,
+		]) {
 			return .jpegXL
 		}
 		//JPEG: FF D8 FF

--- a/Sources/CommProtocol/IdentityExchange/AgentHello.swift
+++ b/Sources/CommProtocol/IdentityExchange/AgentHello.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 7/2/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///Format for a card that gets symmetrically encrypted and exchanged

--- a/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
+++ b/Sources/CommProtocol/IdentityExchange/AppWelcome.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 2/9/25.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///This is the accompanying Application-level data to an MLS welcome, issued in response

--- a/Sources/CommProtocol/IdentityExchange/IdentityIntroduction.swift
+++ b/Sources/CommProtocol/IdentityExchange/IdentityIntroduction.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 8/3/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 //Shared across AgentHello, AgentHelloReply,

--- a/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/AgentKeys.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 6/12/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///- To permit cryptographic flexibility, we

--- a/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
+++ b/Sources/CommProtocol/IdentityKeys/CoreAgentTypes.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 8/14/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 //only using this for the exchange, not subsequent proposals

--- a/Sources/CommProtocol/IdentityKeys/Crypto+Extensions.swift
+++ b/Sources/CommProtocol/IdentityKeys/Crypto+Extensions.swift
@@ -1,12 +1,12 @@
 //
-//  CryptoKit+Extensions.swift
+//  Crypto+Extensions.swift
 //
 //
 //  Created by Mark Xue on 6/12/24.
 //
 
-import CryptoKit
-///Protocol conformance for the bare CryptoKit key types
+import Crypto
+///Protocol conformance for the bare Crypto key types
 import Foundation
 
 public protocol RawRepresentableKey {

--- a/Sources/CommProtocol/IdentityKeys/Curve25519+SigningKey.swift
+++ b/Sources/CommProtocol/IdentityKeys/Curve25519+SigningKey.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 6/15/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 extension Curve25519.Signing.PrivateKey: PrivateSigningKey {

--- a/Sources/CommProtocol/IdentityKeys/IdentityKeys+Migrate.swift
+++ b/Sources/CommProtocol/IdentityKeys/IdentityKeys+Migrate.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 9/14/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 extension IdentityPrivateKey {

--- a/Sources/CommProtocol/IdentityKeys/IdentityKeys.swift
+++ b/Sources/CommProtocol/IdentityKeys/IdentityKeys.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 6/15/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///- To permit cryptographic flexibility, we use 2 layers of abstraction:

--- a/Sources/CommProtocol/IdentityKeys/SigningKey.swift
+++ b/Sources/CommProtocol/IdentityKeys/SigningKey.swift
@@ -5,13 +5,13 @@
 //  Created by Mark Xue on 6/12/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///# Key Abstractions
-///We introduce type abstractions atop the basic CryptoKit primitive so we have type-enforced domain separation
+///We introduce type abstractions atop the basic Crypto primitive so we have type-enforced domain separation
 ///and introduce cryptographic agility by abstracting the typed object into a protocol
-///- Bare CryptoKit Key
+///- Bare Crypto Key
 /// - Can be archived in string format (typically rawRepresentable -> Base64 encoded
 /// - pseudo-stable (modulo padding)
 ///- RoledSigningKey

--- a/Sources/CommProtocol/IdentityUpdate/AgentUpdateV2.swift
+++ b/Sources/CommProtocol/IdentityUpdate/AgentUpdateV2.swift
@@ -18,99 +18,99 @@
 import Foundation
 
 public struct AgentUpdateV2: Sendable, Equatable {
-    public let version: SemanticVersion
-    public let isAppClip: Bool
-    public let grants: [MailboxGrant]
+	public let version: SemanticVersion
+	public let isAppClip: Bool
+	public let grants: [MailboxGrant]
 
-    public init(version: SemanticVersion, isAppClip: Bool, grants: [MailboxGrant]) {
-        self.version = version
-        self.isAppClip = isAppClip
-        self.grants = grants
-    }
+	public init(version: SemanticVersion, isAppClip: Bool, grants: [MailboxGrant]) {
+		self.version = version
+		self.isAppClip = isAppClip
+		self.grants = grants
+	}
 
-    ///The signing-body case discriminator. A `CommProposal`'s tag byte is not
-    ///covered by its payload's signature — for tags 1–5 (shipped, preimages
-    ///frozen) the cases are kept apart only by structural parse
-    ///incompatibility, the same property `AnchorHandoff`'s V2 bodies fixed
-    ///with fresh discriminator strings. This case has never shipped, so it
-    ///gets the discriminator from birth: a signature over an `AgentUpdateV2`
-    ///can never verify as any other case's content, independent of how the
-    ///byte shapes evolve. Cases from tag 6 onward should do the same.
-    static let signingDiscriminator = Data("CommProposal.agentUpdateV2".utf8)
+	///The signing-body case discriminator. A `CommProposal`'s tag byte is not
+	///covered by its payload's signature — for tags 1–5 (shipped, preimages
+	///frozen) the cases are kept apart only by structural parse
+	///incompatibility, the same property `AnchorHandoff`'s V2 bodies fixed
+	///with fresh discriminator strings. This case has never shipped, so it
+	///gets the discriminator from birth: a signature over an `AgentUpdateV2`
+	///can never verify as any other case's content, independent of how the
+	///byte shapes evolve. Cases from tag 6 onward should do the same.
+	static let signingDiscriminator = Data("CommProposal.agentUpdateV2".utf8)
 
-    ///Mirrors `AgentUpdate.formatForSigning(updateMessage:context:)` — the
-    ///signature binds the update to the MLS proposal (`updateMessage`) and
-    ///the session `context` — prefixed with ``signingDiscriminator`` to bind
-    ///it to this `CommProposal` case as well.
-    func formatForSigning(
-        updateMessage: Data,
-        context: TypedDigest
-    ) throws -> Data {
-        try Self.signingDiscriminator + wireFormat + updateMessage + context.wireFormat
-    }
+	///Mirrors `AgentUpdate.formatForSigning(updateMessage:context:)` — the
+	///signature binds the update to the MLS proposal (`updateMessage`) and
+	///the session `context` — prefixed with ``signingDiscriminator`` to bind
+	///it to this `CommProposal` case as well.
+	func formatForSigning(
+		updateMessage: Data,
+		context: TypedDigest
+	) throws -> Data {
+		try Self.signingDiscriminator + wireFormat + updateMessage + context.wireFormat
+	}
 }
 
 // MARK: - Wire format
 
 extension AgentUpdateV2 {
-    private struct VersionArchive: Codable {
-        let major: UInt32
-        let minor: UInt32
-        let patch: UInt32
-        let preReleaseSuffix: String?
+	private struct VersionArchive: Codable {
+		let major: UInt32
+		let minor: UInt32
+		let patch: UInt32
+		let preReleaseSuffix: String?
 
-        //WIRE-FROZEN: never change a raw value once shipped.
-        enum CodingKeys: String, CodingKey {
-            case major = "j"
-            case minor = "n"
-            case patch = "p"
-            case preReleaseSuffix = "r"
-        }
-    }
+		//WIRE-FROZEN: never change a raw value once shipped.
+		enum CodingKeys: String, CodingKey {
+			case major = "j"
+			case minor = "n"
+			case patch = "p"
+			case preReleaseSuffix = "r"
+		}
+	}
 
-    private struct Archive: Codable {
-        let version: VersionArchive
-        let isAppClip: Bool
-        let grants: [Data]  // each entry a MailboxGrant.wireFormat
+	private struct Archive: Codable {
+		let version: VersionArchive
+		let isAppClip: Bool
+		let grants: [Data]  // each entry a MailboxGrant.wireFormat
 
-        //WIRE-FROZEN: never change a raw value once shipped.
-        enum CodingKeys: String, CodingKey {
-            case version = "v"
-            case isAppClip = "c"
-            case grants = "g"
-        }
-    }
+		//WIRE-FROZEN: never change a raw value once shipped.
+		enum CodingKeys: String, CodingKey {
+			case version = "v"
+			case isAppClip = "c"
+			case grants = "g"
+		}
+	}
 
-    private var cborEncoded: Data {
-        get throws {
-            try DeterministicCbor.encode(
-                Archive(
-                    version: VersionArchive(
-                        major: version.major,
-                        minor: version.minor,
-                        patch: version.patch,
-                        preReleaseSuffix: version.preReleaseSuffix
-                    ),
-                    isAppClip: isAppClip,
-                    grants: try grants.map { try $0.wireFormat }
-                )
-            )
-        }
-    }
+	private var cborEncoded: Data {
+		get throws {
+			try DeterministicCbor.encode(
+				Archive(
+					version: VersionArchive(
+						major: version.major,
+						minor: version.minor,
+						patch: version.patch,
+						preReleaseSuffix: version.preReleaseSuffix
+					),
+					isAppClip: isAppClip,
+					grants: try grants.map { try $0.wireFormat }
+				)
+			)
+		}
+	}
 
-    private init(cborEncoded: Data) throws {
-        let archive = try DeterministicCbor.decode(Archive.self, from: cborEncoded)
-        self.init(
-            version: SemanticVersion(
-                major: archive.version.major,
-                minor: archive.version.minor,
-                patch: archive.version.patch,
-                preReleaseSuffix: archive.version.preReleaseSuffix
-            ),
-            isAppClip: archive.isAppClip,
-            grants: try archive.grants.map { try MailboxGrant(wireFormat: $0) }
-        )
-    }
+	private init(cborEncoded: Data) throws {
+		let archive = try DeterministicCbor.decode(Archive.self, from: cborEncoded)
+		self.init(
+			version: SemanticVersion(
+				major: archive.version.major,
+				minor: archive.version.minor,
+				patch: archive.version.patch,
+				preReleaseSuffix: archive.version.preReleaseSuffix
+			),
+			isAppClip: archive.isAppClip,
+			grants: try archive.grants.map { try MailboxGrant(wireFormat: $0) }
+		)
+	}
 }
 
 // A CBOR value is self-delimiting to its own decoder, but `swift-cbor`'s
@@ -119,12 +119,12 @@ extension AgentUpdateV2 {
 // opaque `Data` field: `Data: LinearEncodable` supplies the length prefix and
 // the consumed-byte accounting that `SignedObject`/`CommProposal` need.
 extension AgentUpdateV2: LinearEncodable {
-    public static func parse(_ input: Data) throws -> (AgentUpdateV2, Int) {
-        let (cbor, consumed) = try Data.parse(input)
-        return (try AgentUpdateV2(cborEncoded: cbor), consumed)
-    }
+	public static func parse(_ input: Data) throws -> (AgentUpdateV2, Int) {
+		let (cbor, consumed) = try Data.parse(input)
+		return (try AgentUpdateV2(cborEncoded: cbor), consumed)
+	}
 
-    public var wireFormat: Data {
-        get throws { try cborEncoded.wireFormat }
-    }
+	public var wireFormat: Data {
+		get throws { try cborEncoded.wireFormat }
+	}
 }

--- a/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
+++ b/Sources/CommProtocol/IdentityUpdate/CommProposal.swift
@@ -163,7 +163,10 @@ public enum CommProposal: LinearEncodable, Equatable, Sendable {
 					(SignedObject<IdentityMutableData>?).self,
 					input: remainder
 				)
-			return (.agentUpdateV2(signedAgentUpdateV2, signedIdentityMutable), consumed + 1)
+			return (
+				.agentUpdateV2(signedAgentUpdateV2, signedIdentityMutable),
+				consumed + 1
+			)
 		}
 
 	}

--- a/Sources/CommProtocol/IdentityUpdate/TypedDigest.swift
+++ b/Sources/CommProtocol/IdentityUpdate/TypedDigest.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 7/26/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 public struct TypedDigest: DefinedWidthBinary, Sendable, Hashable, Equatable {

--- a/Sources/CommProtocol/Objects/DataIdentifier.swift
+++ b/Sources/CommProtocol/Objects/DataIdentifier.swift
@@ -8,7 +8,7 @@
 ///Squint and this looks like a TypedDigest. This is a defined width series of bits we use as a nonce, seed, or
 ///as an identifier where we would otherwise use a UUID
 
-import CryptoKit
+import Crypto
 import Foundation
 
 public struct DataIdentifier: DefinedWidthBinary, Sendable, Equatable, Hashable {

--- a/Sources/CommProtocol/Objects/MailboxGrant.swift
+++ b/Sources/CommProtocol/Objects/MailboxGrant.swift
@@ -4,7 +4,7 @@
 //
 
 import Base64
-import CryptoKit
+import Crypto
 import Foundation
 
 /// An authenticated mailbox address, minted by a server and shared with a
@@ -20,159 +20,159 @@ import Foundation
 /// `deriveMailboxAddress`/`computePutTag` (`authentication/mailbox-hmac.ts`)
 /// byte-for-byte, so KATs are shared between the two implementations.
 public struct MailboxGrant: Sendable {
-    public let authKey: TypedKeyMaterial  // .hmacSha256, 32B
-    public let serviceHost: String
-    public let expiration: RoundedDate
+	public let authKey: TypedKeyMaterial  // .hmacSha256, 32B
+	public let serviceHost: String
+	public let expiration: RoundedDate
 
-    public init(
-        authKey: TypedKeyMaterial,
-        serviceHost: String,
-        expiration: Date
-    ) throws(LinearEncodingError) {
-        try self.init(
-            authKey: authKey,
-            serviceHost: serviceHost,
-            expiration: RoundedDate(date: expiration)
-        )
-    }
+	public init(
+		authKey: TypedKeyMaterial,
+		serviceHost: String,
+		expiration: Date
+	) throws(LinearEncodingError) {
+		try self.init(
+			authKey: authKey,
+			serviceHost: serviceHost,
+			expiration: RoundedDate(date: expiration)
+		)
+	}
 
-    init(
-        authKey: TypedKeyMaterial,
-        serviceHost: String,
-        expiration: RoundedDate
-    ) throws(LinearEncodingError) {
-        guard authKey.algorithm == .hmacSha256 else {
-            throw .mismatchedAlgorithms(expected: .hmacSha256, found: authKey.algorithm)
-        }
-        self.authKey = authKey
-        self.serviceHost = serviceHost
-        self.expiration = expiration
-    }
+	init(
+		authKey: TypedKeyMaterial,
+		serviceHost: String,
+		expiration: RoundedDate
+	) throws(LinearEncodingError) {
+		guard authKey.algorithm == .hmacSha256 else {
+			throw .mismatchedAlgorithms(expected: .hmacSha256, found: authKey.algorithm)
+		}
+		self.authKey = authKey
+		self.serviceHost = serviceHost
+		self.expiration = expiration
+	}
 }
 
 // A grant is identified by its key and host, not its expiration — matching
 // `ProtocolAddress`'s precedent (the type it succeeds).
 extension MailboxGrant: Equatable {
-    public static func == (lhs: MailboxGrant, rhs: MailboxGrant) -> Bool {
-        lhs.authKey == rhs.authKey && lhs.serviceHost == rhs.serviceHost
-    }
+	public static func == (lhs: MailboxGrant, rhs: MailboxGrant) -> Bool {
+		lhs.authKey == rhs.authKey && lhs.serviceHost == rhs.serviceHost
+	}
 }
 
 // MARK: - Derivation
 
 extension MailboxGrant {
-    private static let addressLabel = Data("germ-addr:v1".utf8)
-    private static let putLabel = Data("germ-put:v1".utf8)
+	private static let addressLabel = Data("germ-addr:v1".utf8)
+	private static let putLabel = Data("germ-put:v1".utf8)
 
-    /// The address a sender messages to reach this grant's holder — derived,
-    /// never transmitted. `base64url(HMAC-SHA256(authKey, "germ-addr:v1" ‖
-    /// serviceHost))`, unpadded.
-    public var address: String {
-        let key = SymmetricKey(data: authKey.keyData)
-        let message = Self.addressLabel + Data(serviceHost.utf8)
-        let mac = HMAC<SHA256>.authenticationCode(for: message, using: key)
-        return Data(mac).base64URLEncoded(padded: false)
-    }
+	/// The address a sender messages to reach this grant's holder — derived,
+	/// never transmitted. `base64url(HMAC-SHA256(authKey, "germ-addr:v1" ‖
+	/// serviceHost))`, unpadded.
+	public var address: String {
+		let key = SymmetricKey(data: authKey.keyData)
+		let message = Self.addressLabel + Data(serviceHost.utf8)
+		let mac = HMAC<SHA256>.authenticationCode(for: message, using: key)
+		return Data(mac).base64URLEncoded(padded: false)
+	}
 
-    /// The tag a put's `Authorization` header carries, authenticating a body
-    /// whose digest is `bodyDigest` against this grant's `nonce`-bound
-    /// challenge. `HMAC-SHA256(authKey, "germ-put:v1" ‖ address ‖ nonce ‖
-    /// bodyDigest)`.
-    ///
-    /// Byte representations are fixed, matching the server's contract
-    /// (`mailbox-hmac.ts`'s header comment): `address` is the UTF-8 bytes of
-    /// its base64url *string* form (43 bytes), `nonce` is the raw bytes
-    /// returned by the put-challenge (not re-encoded), and `bodyDigest` is
-    /// the raw 32-byte SHA-256 output over the exact request body bytes.
-    public func putTag(nonce: Data, bodyDigest: Data) -> Data {
-        let key = SymmetricKey(data: authKey.keyData)
-        let message = Self.putLabel + Data(address.utf8) + nonce + bodyDigest
-        let mac = HMAC<SHA256>.authenticationCode(for: message, using: key)
-        return Data(mac)
-    }
+	/// The tag a put's `Authorization` header carries, authenticating a body
+	/// whose digest is `bodyDigest` against this grant's `nonce`-bound
+	/// challenge. `HMAC-SHA256(authKey, "germ-put:v1" ‖ address ‖ nonce ‖
+	/// bodyDigest)`.
+	///
+	/// Byte representations are fixed, matching the server's contract
+	/// (`mailbox-hmac.ts`'s header comment): `address` is the UTF-8 bytes of
+	/// its base64url *string* form (43 bytes), `nonce` is the raw bytes
+	/// returned by the put-challenge (not re-encoded), and `bodyDigest` is
+	/// the raw 32-byte SHA-256 output over the exact request body bytes.
+	public func putTag(nonce: Data, bodyDigest: Data) -> Data {
+		let key = SymmetricKey(data: authKey.keyData)
+		let message = Self.putLabel + Data(address.utf8) + nonce + bodyDigest
+		let mac = HMAC<SHA256>.authenticationCode(for: message, using: key)
+		return Data(mac)
+	}
 }
 
 // MARK: - Wire format
 
 extension MailboxGrant {
-    /// The peer-to-peer carriage form — a deterministic-CBOR map, nested
-    /// inside `AgentUpdateV2.grants` (see `DeterministicCbor`'s doc comment
-    /// for why the keys are short strings, not integers).
-    private struct Archive: Codable {
-        let authKey: Data  // TypedKeyMaterial.wireFormat: 1 algorithm byte + 32 key bytes
-        let serviceHost: String
-        let expiration: UInt32  // RoundedDate.hoursSinceEpoch
+	/// The peer-to-peer carriage form — a deterministic-CBOR map, nested
+	/// inside `AgentUpdateV2.grants` (see `DeterministicCbor`'s doc comment
+	/// for why the keys are short strings, not integers).
+	private struct Archive: Codable {
+		let authKey: Data  // TypedKeyMaterial.wireFormat: 1 algorithm byte + 32 key bytes
+		let serviceHost: String
+		let expiration: UInt32  // RoundedDate.hoursSinceEpoch
 
-        //WIRE-FROZEN: never change a raw value once shipped.
-        enum CodingKeys: String, CodingKey {
-            case authKey = "k"
-            case serviceHost = "h"
-            case expiration = "e"
-        }
-    }
+		//WIRE-FROZEN: never change a raw value once shipped.
+		enum CodingKeys: String, CodingKey {
+			case authKey = "k"
+			case serviceHost = "h"
+			case expiration = "e"
+		}
+	}
 
-    public var wireFormat: Data {
-        get throws {
-            try DeterministicCbor.encode(
-                Archive(
-                    authKey: authKey.wireFormat,
-                    serviceHost: serviceHost,
-                    expiration: expiration.hoursSinceEpoch
-                )
-            )
-        }
-    }
+	public var wireFormat: Data {
+		get throws {
+			try DeterministicCbor.encode(
+				Archive(
+					authKey: authKey.wireFormat,
+					serviceHost: serviceHost,
+					expiration: expiration.hoursSinceEpoch
+				)
+			)
+		}
+	}
 
-    public init(wireFormat: Data) throws {
-        let archive = try DeterministicCbor.decode(Archive.self, from: wireFormat)
-        try self.init(
-            authKey: TypedKeyMaterial(wireFormat: archive.authKey),
-            serviceHost: archive.serviceHost,
-            expiration: RoundedDate(hoursSinceEpoch: archive.expiration)
-        )
-    }
+	public init(wireFormat: Data) throws {
+		let archive = try DeterministicCbor.decode(Archive.self, from: wireFormat)
+		try self.init(
+			authKey: TypedKeyMaterial(wireFormat: archive.authKey),
+			serviceHost: archive.serviceHost,
+			expiration: RoundedDate(hoursSinceEpoch: archive.expiration)
+		)
+	}
 }
 
 // MARK: - ProtocolAddress bridge
 
 extension ProtocolAddress {
-    /// Non-nil when `identifier` decodes as a mailbox grant's `authKey`
-    /// (exactly 32 raw bytes) rather than a legacy `crypto.randomUUID()`
-    /// address (36 characters, which decode as base64url to 27 bytes since
-    /// `-` is in the alphabet — the lengths never collide).
-    ///
-    /// This is the transitional carriage for surfaces that cannot take a
-    /// wire-shape change (`PQAppWelcome`/`PQAnchorWelcome`/handoffs — see
-    /// docs/attachment-mailbox-delivery.md, "Wire types"): only an `authKey`
-    /// ever rides `identifier` in this format, never the derived `address`
-    /// — the address is also 32 raw bytes and indistinguishable by shape, so
-    /// the discrimination is sound only because both ends derive it from the
-    /// key. `init(mailboxGrant:)`, below, is the only sanctioned way to build
-    /// a grant-bearing `ProtocolAddress`; nothing else should hand-construct
-    /// one with a base64url identifier.
-    public var mailboxGrant: MailboxGrant? {
-        guard let keyData = try? Data(base64URLEncoded: identifier),
-            keyData.count == TypedKeyMaterial.Algorithms.hmacSha256.contentByteSize,
-            let authKey = try? TypedKeyMaterial(
-                algorithm: .hmacSha256,
-                symmetricKey: SymmetricKey(data: keyData)
-            )
-        else {
-            return nil
-        }
-        return try? MailboxGrant(
-            authKey: authKey,
-            serviceHost: serviceHost,
-            expiration: expiration
-        )
-    }
+	/// Non-nil when `identifier` decodes as a mailbox grant's `authKey`
+	/// (exactly 32 raw bytes) rather than a legacy `crypto.randomUUID()`
+	/// address (36 characters, which decode as base64url to 27 bytes since
+	/// `-` is in the alphabet — the lengths never collide).
+	///
+	/// This is the transitional carriage for surfaces that cannot take a
+	/// wire-shape change (`PQAppWelcome`/`PQAnchorWelcome`/handoffs — see
+	/// docs/attachment-mailbox-delivery.md, "Wire types"): only an `authKey`
+	/// ever rides `identifier` in this format, never the derived `address`
+	/// — the address is also 32 raw bytes and indistinguishable by shape, so
+	/// the discrimination is sound only because both ends derive it from the
+	/// key. `init(mailboxGrant:)`, below, is the only sanctioned way to build
+	/// a grant-bearing `ProtocolAddress`; nothing else should hand-construct
+	/// one with a base64url identifier.
+	public var mailboxGrant: MailboxGrant? {
+		guard let keyData = try? Data(base64URLEncoded: identifier),
+			keyData.count == TypedKeyMaterial.Algorithms.hmacSha256.contentByteSize,
+			let authKey = try? TypedKeyMaterial(
+				algorithm: .hmacSha256,
+				symmetricKey: SymmetricKey(data: keyData)
+			)
+		else {
+			return nil
+		}
+		return try? MailboxGrant(
+			authKey: authKey,
+			serviceHost: serviceHost,
+			expiration: expiration
+		)
+	}
 
-    /// Builds the transitional carriage of `mailboxGrant` — see `mailboxGrant`.
-    public init(mailboxGrant: MailboxGrant) {
-        self.init(
-            identifier: mailboxGrant.authKey.keyData.base64URLEncoded(padded: false),
-            serviceHost: mailboxGrant.serviceHost,
-            expiration: mailboxGrant.expiration
-        )
-    }
+	/// Builds the transitional carriage of `mailboxGrant` — see `mailboxGrant`.
+	public init(mailboxGrant: MailboxGrant) {
+		self.init(
+			identifier: mailboxGrant.authKey.keyData.base64URLEncoded(padded: false),
+			serviceHost: mailboxGrant.serviceHost,
+			expiration: mailboxGrant.expiration
+		)
+	}
 }

--- a/Sources/CommProtocol/Objects/Resource.swift
+++ b/Sources/CommProtocol/Objects/Resource.swift
@@ -6,7 +6,7 @@
 //
 
 import Base64
-@preconcurrency import CryptoKit
+@preconcurrency import Crypto
 import Foundation
 import GermConvenience
 

--- a/Sources/CommProtocol/Objects/SignedObject.swift
+++ b/Sources/CommProtocol/Objects/SignedObject.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 6/16/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 public struct SignedObject<Content: LinearEncodable> {

--- a/Sources/CommProtocol/TypedKeyMaterial.swift
+++ b/Sources/CommProtocol/TypedKeyMaterial.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 6/23/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 
 ///Binary encoding of key data that prepends a byte enum of the algo type.

--- a/Sources/CommProtocolMocks/MockIdentity.swift
+++ b/Sources/CommProtocolMocks/MockIdentity.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocol
-import CryptoKit
+import Crypto
 
 extension IdentityPrivateKey {
 	public static func mock() throws -> Self {

--- a/Sources/CommProtocolMocks/Mocks.swift
+++ b/Sources/CommProtocolMocks/Mocks.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocol
-import CryptoKit
+import Crypto
 import Foundation
 
 extension AgentUpdate {

--- a/Tests/CommProtocolTests/AgentTests.swift
+++ b/Tests/CommProtocolTests/AgentTests.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 6/13/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorAPIs.swift
@@ -9,7 +9,7 @@ import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocol
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Testing
 
 struct AnchorAPITests {

--- a/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorHandoffV2Tests.swift
@@ -15,7 +15,7 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 
@@ -172,7 +172,10 @@ struct AnchorHandoffV2Tests {
 		let newAgent = AgentPrivateKey()
 		let real = opaqueDigest(0xA1)
 
-		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+		#expect(
+			throws: ProtocolError.unexpected(
+				"empty digest bytes in opaque handoff body")
+		) {
 			_ = try self.alexPrivateAnchor.createNewAgentHandoff(
 				agentUpdate: .mock(),
 				newAgent: newAgent,
@@ -181,7 +184,10 @@ struct AnchorHandoffV2Tests {
 				mlsUpdateDigest: real
 			)
 		}
-		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+		#expect(
+			throws: ProtocolError.unexpected(
+				"empty digest bytes in opaque handoff body")
+		) {
 			_ = try self.alexPrivateAnchor.createNewAgentHandoff(
 				agentUpdate: .mock(),
 				newAgent: newAgent,
@@ -198,14 +204,20 @@ struct AnchorHandoffV2Tests {
 			groupContext: real,
 			mlsUpdateDigest: real
 		)
-		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+		#expect(
+			throws: ProtocolError.unexpected(
+				"empty digest bytes in opaque handoff body")
+		) {
 			_ = try verified.agent.verify(
 				anchorHandoff: handoff,
 				context: Data(),
 				mlsUpdateDigest: real
 			)
 		}
-		#expect(throws: ProtocolError.unexpected("empty digest bytes in opaque handoff body")) {
+		#expect(
+			throws: ProtocolError.unexpected(
+				"empty digest bytes in opaque handoff body")
+		) {
 			_ = try verified.agent.verify(
 				anchorHandoff: handoff,
 				context: real,
@@ -231,20 +243,29 @@ struct AnchorHandoffV2Tests {
 			AnchorHandoff.ActiveAgentBodyV2.discriminator,
 			AnchorHandoff.RetiredAgentBodyV2.discriminator,
 		]
-		#expect(Set(all).count == all.count, "handoff discriminators must be pairwise distinct")
+		#expect(
+			Set(all).count == all.count,
+			"handoff discriminators must be pairwise distinct")
 	}
 
 	/// Pins the frozen swap so nobody "corrects" it in place and silently breaks
 	/// every live relationship's handoff verification.
 	@Test func v1SwapStaysFrozenAndV2IsCorrect() {
-		#expect(AnchorHandoff.ActiveAgentBody.discriminator == "AnchorHandoff.RetiredAgentBody")
-		#expect(AnchorHandoff.RetiredAgentBody.discriminator == "AnchorHandoff.ActiveAgentBody")
+		#expect(
+			AnchorHandoff.ActiveAgentBody.discriminator
+				== "AnchorHandoff.RetiredAgentBody")
+		#expect(
+			AnchorHandoff.RetiredAgentBody.discriminator
+				== "AnchorHandoff.ActiveAgentBody")
 
 		#expect(
-			AnchorHandoff.ActiveAnchorBodyV2.discriminator == "AnchorHandoff.ActiveAnchorBody.v2")
+			AnchorHandoff.ActiveAnchorBodyV2.discriminator
+				== "AnchorHandoff.ActiveAnchorBody.v2")
 		#expect(
-			AnchorHandoff.ActiveAgentBodyV2.discriminator == "AnchorHandoff.ActiveAgentBody.v2")
+			AnchorHandoff.ActiveAgentBodyV2.discriminator
+				== "AnchorHandoff.ActiveAgentBody.v2")
 		#expect(
-			AnchorHandoff.RetiredAgentBodyV2.discriminator == "AnchorHandoff.RetiredAgentBody.v2")
+			AnchorHandoff.RetiredAgentBodyV2.discriminator
+				== "AnchorHandoff.RetiredAgentBody.v2")
 	}
 }

--- a/Tests/CommProtocolTests/Anchors/AnchorSuccessionTests.swift
+++ b/Tests/CommProtocolTests/Anchors/AnchorSuccessionTests.swift
@@ -10,7 +10,7 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocol
-import CryptoKit
+import Crypto
 import Testing
 
 struct AnchorSuccessionTests {

--- a/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
+++ b/Tests/CommProtocolTests/Anchors/PQAnchorWelcomeTests.swift
@@ -8,7 +8,7 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/CommProposalTests.swift
+++ b/Tests/CommProtocolTests/CommProposalTests.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/CommProtocolTests.swift
+++ b/Tests/CommProtocolTests/CommProtocolTests.swift
@@ -7,7 +7,7 @@
 
 import CommProtocol
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/DeclaredWidthTests.swift
+++ b/Tests/CommProtocolTests/DeclaredWidthTests.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 7/27/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
+++ b/Tests/CommProtocolTests/DefinedWidthStartIndexTests.swift
@@ -5,7 +5,7 @@
 //  Created by Mark Xue on 8/4/26.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/DescribedImageTests.swift
+++ b/Tests/CommProtocolTests/DescribedImageTests.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 7/22/26.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 
@@ -58,7 +58,10 @@ struct DescribedImageTests {
 
 	@Test func testDetectRejectsOther() {
 		//PNG magic
-		#expect(ImageType.detect(from: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])) == nil)
+		#expect(
+			ImageType.detect(
+				from: Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])) == nil
+		)
 		#expect(ImageType.detect(from: Data()) == nil)
 		#expect(ImageType.detect(from: Data([0xFF])) == nil)
 	}

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloDualOfferTests.swift
@@ -4,7 +4,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloReplyTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloReplyTests.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Testing
 
 @testable import CommProtocol

--- a/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AgentHelloTests.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityExchange/AppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/AppWelcomeTests.swift
@@ -7,7 +7,7 @@
 
 import CommProtocol
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Testing
 
 struct AppWelcomeTests {

--- a/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
+++ b/Tests/CommProtocolTests/IdentityExchange/PQAppWelcomeTests.swift
@@ -7,7 +7,7 @@
 
 import CommProtocol
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityKeyTests.swift
+++ b/Tests/CommProtocolTests/IdentityKeyTests.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentHandoffDomainSeparationTests.swift
@@ -8,7 +8,7 @@
 //  byte-identical to the plain concatenation.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
+++ b/Tests/CommProtocolTests/IdentityUpdate/AgentUpdateV2Tests.swift
@@ -6,358 +6,358 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 
 @testable import CommProtocol
 
 struct AgentUpdateV2Tests {
-    let knownIdentityKey: IdentityPrivateKey
-    let knownSignedIdentity: SignedObject<CoreIdentity>
-    let knownAgent: AgentPrivateKey
+	let knownIdentityKey: IdentityPrivateKey
+	let knownSignedIdentity: SignedObject<CoreIdentity>
+	let knownAgent: AgentPrivateKey
 
-    init() throws {
-        (knownIdentityKey, knownSignedIdentity) = try Mocks.mockIdentity()
-        knownAgent = .init()
-    }
+	init() throws {
+		(knownIdentityKey, knownSignedIdentity) = try Mocks.mockIdentity()
+		knownAgent = .init()
+	}
 
-    // MARK: - CBOR round-trip
+	// MARK: - CBOR round-trip
 
-    @Test func testCborRoundTrip() throws {
-        let original = AgentUpdateV2.mock()
-        let encoded = try original.wireFormat
-        let (decoded, consumed) = try AgentUpdateV2.parse(encoded)
-        #expect(consumed == encoded.count)
-        #expect(decoded == original)
-    }
+	@Test func testCborRoundTrip() throws {
+		let original = AgentUpdateV2.mock()
+		let encoded = try original.wireFormat
+		let (decoded, consumed) = try AgentUpdateV2.parse(encoded)
+		#expect(consumed == encoded.count)
+		#expect(decoded == original)
+	}
 
-    /// `SemanticVersion.mock()` includes a pre-release suffix only at random,
-    /// so the mock round-trip above exercises the version archive's "r" key
-    /// probabilistically — this pins both branches deterministically.
-    @Test func testCborRoundTripVersionSuffixBothWays() throws {
-        for suffix in [String?.none, "-beta.1"] {
-            let original = AgentUpdateV2(
-                version: SemanticVersion(
-                    major: 2, minor: 4, patch: 0, preReleaseSuffix: suffix
-                ),
-                isAppClip: false,
-                grants: [.mock()]
-            )
-            let (decoded, _) = try AgentUpdateV2.parse(try original.wireFormat)
-            #expect(decoded == original)
-            #expect(decoded.version.string == original.version.string)
-        }
-    }
+	/// `SemanticVersion.mock()` includes a pre-release suffix only at random,
+	/// so the mock round-trip above exercises the version archive's "r" key
+	/// probabilistically — this pins both branches deterministically.
+	@Test func testCborRoundTripVersionSuffixBothWays() throws {
+		for suffix in [String?.none, "-beta.1"] {
+			let original = AgentUpdateV2(
+				version: SemanticVersion(
+					major: 2, minor: 4, patch: 0, preReleaseSuffix: suffix
+				),
+				isAppClip: false,
+				grants: [.mock()]
+			)
+			let (decoded, _) = try AgentUpdateV2.parse(try original.wireFormat)
+			#expect(decoded == original)
+			#expect(decoded.version.string == original.version.string)
+		}
+	}
 
-    @Test func testGrantsOnlyNoLegacyAddressesField() {
-        // Structural check that the type itself has no way to carry a legacy
-        // address list — the whole point of the gated cutover
-        // (docs/attachment-mailbox-delivery.md, "Wire types"). If this ever
-        // fails to compile, `AgentUpdateV2` grew an `addresses` field.
-        let update = AgentUpdateV2.mock()
-        let mirror = Mirror(reflecting: update)
-        #expect(mirror.children.map { $0.label } == ["version", "isAppClip", "grants"])
-    }
+	@Test func testGrantsOnlyNoLegacyAddressesField() {
+		// Structural check that the type itself has no way to carry a legacy
+		// address list — the whole point of the gated cutover
+		// (docs/attachment-mailbox-delivery.md, "Wire types"). If this ever
+		// fails to compile, `AgentUpdateV2` grew an `addresses` field.
+		let update = AgentUpdateV2.mock()
+		let mirror = Mirror(reflecting: update)
+		#expect(mirror.children.map { $0.label } == ["version", "isAppClip", "grants"])
+	}
 
-    // MARK: - Wire-pinning
+	// MARK: - Wire-pinning
 
-    @Test func testCborWireFormatGolden() throws {
-        let key = try TypedKeyMaterial(
-            algorithm: .hmacSha256,
-            symmetricKey: SymmetricKey(data: Data(count: 32))
-        )
-        let grant = try MailboxGrant(
-            authKey: key,
-            serviceHost: "ger.mx",
-            expiration: RoundedDate(hoursSinceEpoch: 471442)
-        )
-        let update = AgentUpdateV2(
-            version: SemanticVersion(major: 2, minor: 4, patch: 0),
-            isAppClip: false,
-            grants: [grant]
-        )
-        let encoded = try update.wireFormat
-        // Locks the encoding against drift, same discipline as
-        // MailboxGrantTests.testCborWireFormatGolden. Byte-verified at
-        // introduction with an independent CBOR parse: a length-prefixed
-        // `Data` (0x4b = 75 bytes) wrapping a 3-key canonical map ("c" <
-        // "g" < "v" bytewise) — isAppClip=false, a one-element grants array
-        // whose entry is exactly the golden `MailboxGrant` bytes, and the
-        // version {major:2, minor:4, patch:0}.
-        #expect(
-            encoded
-                == Data(
-                    hexString:
-                        "4ba36163f46167815836a361651a000731926168666765722e6d78616b58210500000000000000000000000000000000000000000000000000000000000000006176a3616a02616e04617000"
-                )
-        )
-    }
+	@Test func testCborWireFormatGolden() throws {
+		let key = try TypedKeyMaterial(
+			algorithm: .hmacSha256,
+			symmetricKey: SymmetricKey(data: Data(count: 32))
+		)
+		let grant = try MailboxGrant(
+			authKey: key,
+			serviceHost: "ger.mx",
+			expiration: RoundedDate(hoursSinceEpoch: 471442)
+		)
+		let update = AgentUpdateV2(
+			version: SemanticVersion(major: 2, minor: 4, patch: 0),
+			isAppClip: false,
+			grants: [grant]
+		)
+		let encoded = try update.wireFormat
+		// Locks the encoding against drift, same discipline as
+		// MailboxGrantTests.testCborWireFormatGolden. Byte-verified at
+		// introduction with an independent CBOR parse: a length-prefixed
+		// `Data` (0x4b = 75 bytes) wrapping a 3-key canonical map ("c" <
+		// "g" < "v" bytewise) — isAppClip=false, a one-element grants array
+		// whose entry is exactly the golden `MailboxGrant` bytes, and the
+		// version {major:2, minor:4, patch:0}.
+		#expect(
+			encoded
+				== Data(
+					hexString:
+						"4ba36163f46167815836a361651a000731926168666765722e6d78616b58210500000000000000000000000000000000000000000000000000000000000000006176a3616a02616e04617000"
+				)
+		)
+	}
 
-    /// The `ProposalType` tags of every case that predates this one must not
-    /// move — that's what "legacy peers keep receiving the classic triple
-    /// byte-identically" actually depends on, since `.agentUpdateV2` is
-    /// appended, not inserted.
-    @Test func testExistingProposalTagsUnchanged() {
-        #expect(CommProposal.ProposalType.sameAgent.rawValue == 1)
-        #expect(CommProposal.ProposalType.sameIdentity.rawValue == 2)
-        #expect(CommProposal.ProposalType.newIdentity.rawValue == 3)
-        #expect(CommProposal.ProposalType.anchorHandOff.rawValue == 4)
-        #expect(CommProposal.ProposalType.pqCardUpgrade.rawValue == 5)
-        #expect(CommProposal.ProposalType.agentUpdateV2.rawValue == 6)
-    }
+	/// The `ProposalType` tags of every case that predates this one must not
+	/// move — that's what "legacy peers keep receiving the classic triple
+	/// byte-identically" actually depends on, since `.agentUpdateV2` is
+	/// appended, not inserted.
+	@Test func testExistingProposalTagsUnchanged() {
+		#expect(CommProposal.ProposalType.sameAgent.rawValue == 1)
+		#expect(CommProposal.ProposalType.sameIdentity.rawValue == 2)
+		#expect(CommProposal.ProposalType.newIdentity.rawValue == 3)
+		#expect(CommProposal.ProposalType.anchorHandOff.rawValue == 4)
+		#expect(CommProposal.ProposalType.pqCardUpgrade.rawValue == 5)
+		#expect(CommProposal.ProposalType.agentUpdateV2.rawValue == 6)
+	}
 
-    /// A hex pin of `.sameAgent`'s deterministic portion (the `ProposalType`
-    /// tag byte + `AgentUpdate`'s own encoding) under fixed inputs — proving
-    /// the pre-existing case's bytes are unaffected by this file's changes.
-    /// Extends the golden-hex pattern in `AgentHelloDualOfferTests`.
-    ///
-    /// Stops short of pinning the trailing `TypedSignature`: CryptoKit's
-    /// Ed25519 does not reproduce identical signature bytes for the same key
-    /// and message across runs (verified empirically — two runs against this
-    /// exact fixture diverged only in that trailing region), unlike RFC
-    /// 8032's nominally-deterministic algorithm. The `validate` call below
-    /// is the correctness check for that region instead: it can only succeed
-    /// if the signature, whatever its bytes, verifies against exactly this
-    /// `AgentUpdate` and signing key.
-    @Test func testSameAgentProposalGoldenHexUnaffected() throws {
-        let fixedAgent = try AgentPrivateKey(
-            archive: .init(prefix: .curve25519Signing, checkedData: Data(count: 32))
-        )
-        let fixedAddress = ProtocolAddress(
-            identifier: "00000000-0000-0000-0000-000000000000",
-            serviceHost: "ger.mx",
-            expiration: RoundedDate(hoursSinceEpoch: 471442)
-        )
-        let fixedAgentUpdate = AgentUpdate(
-            version: SemanticVersion(major: 1, minor: 0, patch: 0),
-            isAppClip: false,
-            addresses: [fixedAddress]
-        )
-        let fixedMessage = Data([0x01, 0x02, 0x03])
-        let fixedContext = TypedDigest(prefix: .sha256, over: Data([0x00]))
+	/// A hex pin of `.sameAgent`'s deterministic portion (the `ProposalType`
+	/// tag byte + `AgentUpdate`'s own encoding) under fixed inputs — proving
+	/// the pre-existing case's bytes are unaffected by this file's changes.
+	/// Extends the golden-hex pattern in `AgentHelloDualOfferTests`.
+	///
+	/// Stops short of pinning the trailing `TypedSignature`: CryptoKit's
+	/// Ed25519 does not reproduce identical signature bytes for the same key
+	/// and message across runs (verified empirically — two runs against this
+	/// exact fixture diverged only in that trailing region), unlike RFC
+	/// 8032's nominally-deterministic algorithm. The `validate` call below
+	/// is the correctness check for that region instead: it can only succeed
+	/// if the signature, whatever its bytes, verifies against exactly this
+	/// `AgentUpdate` and signing key.
+	@Test func testSameAgentProposalGoldenHexUnaffected() throws {
+		let fixedAgent = try AgentPrivateKey(
+			archive: .init(prefix: .curve25519Signing, checkedData: Data(count: 32))
+		)
+		let fixedAddress = ProtocolAddress(
+			identifier: "00000000-0000-0000-0000-000000000000",
+			serviceHost: "ger.mx",
+			expiration: RoundedDate(hoursSinceEpoch: 471442)
+		)
+		let fixedAgentUpdate = AgentUpdate(
+			version: SemanticVersion(major: 1, minor: 0, patch: 0),
+			isAppClip: false,
+			addresses: [fixedAddress]
+		)
+		let fixedMessage = Data([0x01, 0x02, 0x03])
+		let fixedContext = TypedDigest(prefix: .sha256, over: Data([0x00]))
 
-        let proposal = try fixedAgent.proposeLeafNode(
-            leafNodeUpdate: fixedMessage,
-            agentUpdate: fixedAgentUpdate,
-            signedIdentityMutable: nil,
-            context: fixedContext
-        )
-        let encoded = try proposal.wireFormat
-        #expect(encoded.count == 122)  // tag(1) + AgentUpdate(56) + TypedSignature(65)
-        #expect(
-            encoded.prefix(57)
-                == Data(
-                    hexString:
-                        "010100000000012430303030303030302d303030302d303030302d303030302d303030303030303030303030066765722e6d78ff0007319200"
-                )
-        )
+		let proposal = try fixedAgent.proposeLeafNode(
+			leafNodeUpdate: fixedMessage,
+			agentUpdate: fixedAgentUpdate,
+			signedIdentityMutable: nil,
+			context: fixedContext
+		)
+		let encoded = try proposal.wireFormat
+		#expect(encoded.count == 122)  // tag(1) + AgentUpdate(56) + TypedSignature(65)
+		#expect(
+			encoded.prefix(57)
+				== Data(
+					hexString:
+						"010100000000012430303030303030302d303030302d303030302d303030302d303030303030303030303030066765722e6d78ff0007319200"
+				)
+		)
 
-        // And it still validates — this proposal is unaffected end to end,
-        // not merely byte-identical by coincidence.
-        let (parsed, consumed) = try CommProposal.parse(encoded)
-        #expect(consumed == encoded.count)
-        guard case .sameAgent(let signedUpdate, nil) = parsed else {
-            Issue.record("expected .sameAgent")
-            return
-        }
-        let verified = try fixedAgent.publicKey.validate(
-            signedAgentUpdate: signedUpdate,
-            for: fixedMessage,
-            context: fixedContext
-        )
-        #expect(verified == fixedAgentUpdate)
-    }
+		// And it still validates — this proposal is unaffected end to end,
+		// not merely byte-identical by coincidence.
+		let (parsed, consumed) = try CommProposal.parse(encoded)
+		#expect(consumed == encoded.count)
+		guard case .sameAgent(let signedUpdate, nil) = parsed else {
+			Issue.record("expected .sameAgent")
+			return
+		}
+		let verified = try fixedAgent.publicKey.validate(
+			signedAgentUpdate: signedUpdate,
+			for: fixedMessage,
+			context: fixedContext
+		)
+		#expect(verified == fixedAgentUpdate)
+	}
 
-    // MARK: - CommProposal.agentUpdateV2 round-trip
+	// MARK: - CommProposal.agentUpdateV2 round-trip
 
-    @Test func testAgentUpdateV2Proposal() throws {
-        let mockMessage = Mocks.mockMessage()
-        let mockContext = try TypedDigest.mock()
-        let signedIdentityMutable = try knownIdentityKey.sign(mutableData: .mock())
+	@Test func testAgentUpdateV2Proposal() throws {
+		let mockMessage = Mocks.mockMessage()
+		let mockContext = try TypedDigest.mock()
+		let signedIdentityMutable = try knownIdentityKey.sign(mutableData: .mock())
 
-        let proposal = try knownAgent.proposeAgentUpdateV2(
-            leafNodeUpdate: mockMessage,
-            agentUpdate: .mock(),
-            signedIdentityMutable: signedIdentityMutable,
-            context: mockContext
-        )
-        let wireProposal = try proposal.wireFormat
+		let proposal = try knownAgent.proposeAgentUpdateV2(
+			leafNodeUpdate: mockMessage,
+			agentUpdate: .mock(),
+			signedIdentityMutable: signedIdentityMutable,
+			context: mockContext
+		)
+		let wireProposal = try proposal.wireFormat
 
-        let validated = try CommProposal.finalParse(wireProposal)
-            .validate(
-                knownIdentity: knownSignedIdentity.content.id,
-                knownAgent: knownAgent.publicKey,
-                context: mockContext,
-                updateMessage: mockMessage
-            )
+		let validated = try CommProposal.finalParse(wireProposal)
+			.validate(
+				knownIdentity: knownSignedIdentity.content.id,
+				knownAgent: knownAgent.publicKey,
+				context: mockContext,
+				updateMessage: mockMessage
+			)
 
-        guard case .agentUpdateV2(let agentUpdate, let mutableData) = validated else {
-            Issue.record("expected .agentUpdateV2")
-            return
-        }
-        #expect(!agentUpdate.grants.isEmpty)
-        #expect(mutableData != nil)
-    }
+		guard case .agentUpdateV2(let agentUpdate, let mutableData) = validated else {
+			Issue.record("expected .agentUpdateV2")
+			return
+		}
+		#expect(!agentUpdate.grants.isEmpty)
+		#expect(mutableData != nil)
+	}
 
-    @Test func testAgentUpdateV2ProposalRejectsWrongKey() throws {
-        let mockMessage = Mocks.mockMessage()
-        let mockContext = try TypedDigest.mock()
+	@Test func testAgentUpdateV2ProposalRejectsWrongKey() throws {
+		let mockMessage = Mocks.mockMessage()
+		let mockContext = try TypedDigest.mock()
 
-        let proposal = try knownAgent.proposeAgentUpdateV2(
-            leafNodeUpdate: mockMessage,
-            agentUpdate: .mock(),
-            signedIdentityMutable: nil,
-            context: mockContext
-        )
-        let wireProposal = try proposal.wireFormat
-        let wrongKey = AgentPrivateKey()
+		let proposal = try knownAgent.proposeAgentUpdateV2(
+			leafNodeUpdate: mockMessage,
+			agentUpdate: .mock(),
+			signedIdentityMutable: nil,
+			context: mockContext
+		)
+		let wireProposal = try proposal.wireFormat
+		let wrongKey = AgentPrivateKey()
 
-        #expect(throws: ProtocolError.authenticationError) {
-            let _ = try CommProposal.finalParse(wireProposal)
-                .validate(
-                    knownIdentity: knownSignedIdentity.content.id,
-                    knownAgent: wrongKey.publicKey,
-                    context: mockContext,
-                    updateMessage: mockMessage
-                )
-        }
-    }
+		#expect(throws: ProtocolError.authenticationError) {
+			let _ = try CommProposal.finalParse(wireProposal)
+				.validate(
+					knownIdentity: knownSignedIdentity.content.id,
+					knownAgent: wrongKey.publicKey,
+					context: mockContext,
+					updateMessage: mockMessage
+				)
+		}
+	}
 
-    // MARK: - Signing-body case discriminator
+	// MARK: - Signing-body case discriminator
 
-    /// The tag byte of a `CommProposal` is not covered by its payload's
-    /// signature, so `.agentUpdateV2` domain-separates its signing body with a
-    /// case discriminator (unlike tags 1–5, whose preimages shipped frozen).
-    /// Pins the exact preimage layout: discriminator ‖ wireFormat ‖
-    /// updateMessage ‖ context — removing or reordering any element must fail
-    /// here, not in production signature mismatches.
-    @Test func testFormatForSigningCarriesCaseDiscriminator() throws {
-        let update = AgentUpdateV2.mock()
-        let message = Data([0x0A, 0x0B])
-        let context = try TypedDigest.mock()
+	/// The tag byte of a `CommProposal` is not covered by its payload's
+	/// signature, so `.agentUpdateV2` domain-separates its signing body with a
+	/// case discriminator (unlike tags 1–5, whose preimages shipped frozen).
+	/// Pins the exact preimage layout: discriminator ‖ wireFormat ‖
+	/// updateMessage ‖ context — removing or reordering any element must fail
+	/// here, not in production signature mismatches.
+	@Test func testFormatForSigningCarriesCaseDiscriminator() throws {
+		let update = AgentUpdateV2.mock()
+		let message = Data([0x0A, 0x0B])
+		let context = try TypedDigest.mock()
 
-        let preimage = try update.formatForSigning(
-            updateMessage: message,
-            context: context
-        )
-        let expected =
-            try Data("CommProposal.agentUpdateV2".utf8)
-            + update.wireFormat
-            + message
-            + context.wireFormat
-        #expect(preimage == expected)
-    }
+		let preimage = try update.formatForSigning(
+			updateMessage: message,
+			context: context
+		)
+		let expected =
+			try Data("CommProposal.agentUpdateV2".utf8)
+			+ update.wireFormat
+			+ message
+			+ context.wireFormat
+		#expect(preimage == expected)
+	}
 
-    // MARK: - ValidatedForAnchor.agentUpdateV2 (Part 0: PersistedRatchet/AppSession
-    // is the anchor path — .sameAgent's card-side sibling had no anchor-side
-    // handling at all before this, tag 6 fell into `default: throw unsupported`)
+	// MARK: - ValidatedForAnchor.agentUpdateV2 (Part 0: PersistedRatchet/AppSession
+	// is the anchor path — .sameAgent's card-side sibling had no anchor-side
+	// handling at all before this, tag 6 fell into `default: throw unsupported`)
 
-    @Test func testAgentUpdateV2ProposalAnchorValidate() throws {
-        let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
-        let invitationAgent = acceptorAnchor.createHelloAgent()
-        let knownAnchor = PublicAnchorAgent(
-            anchor: acceptorAnchor.publicAnchor,
-            agentKey: invitationAgent.publicKey
-        )
-        let mlsUpdateDigest = try TypedDigest.mock()
-        let mockContext = try TypedDigest.mock()
+	@Test func testAgentUpdateV2ProposalAnchorValidate() throws {
+		let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+		let invitationAgent = acceptorAnchor.createHelloAgent()
+		let knownAnchor = PublicAnchorAgent(
+			anchor: acceptorAnchor.publicAnchor,
+			agentKey: invitationAgent.publicKey
+		)
+		let mlsUpdateDigest = try TypedDigest.mock()
+		let mockContext = try TypedDigest.mock()
 
-        // signedIdentityMutable: nil — the anchor-side signer for
-        // IdentityMutableData is orthogonal to what this test covers (the new
-        // tag-6 branch's AgentUpdateV2 signature verification against the
-        // agent key) and has no established construction pattern in this
-        // test suite; the non-nil arm is exercised card-side already
-        // (testAgentUpdateV2Proposal).
-        let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
-            leafNodeUpdate: mlsUpdateDigest.wireFormat,
-            agentUpdate: .mock(),
-            signedIdentityMutable: nil,
-            context: mockContext
-        )
-        let wireProposal = try proposal.wireFormat
+		// signedIdentityMutable: nil — the anchor-side signer for
+		// IdentityMutableData is orthogonal to what this test covers (the new
+		// tag-6 branch's AgentUpdateV2 signature verification against the
+		// agent key) and has no established construction pattern in this
+		// test suite; the non-nil arm is exercised card-side already
+		// (testAgentUpdateV2Proposal).
+		let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
+			leafNodeUpdate: mlsUpdateDigest.wireFormat,
+			agentUpdate: .mock(),
+			signedIdentityMutable: nil,
+			context: mockContext
+		)
+		let wireProposal = try proposal.wireFormat
 
-        let validated = try CommProposal.finalParse(wireProposal)
-            .validate(
-                knownAnchor: knownAnchor,
-                context: mockContext,
-                mlsUpdateDigest: mlsUpdateDigest
-            )
+		let validated = try CommProposal.finalParse(wireProposal)
+			.validate(
+				knownAnchor: knownAnchor,
+				context: mockContext,
+				mlsUpdateDigest: mlsUpdateDigest
+			)
 
-        guard case .agentUpdateV2(let agentUpdate, let mutableData) = validated else {
-            Issue.record("expected .agentUpdateV2")
-            return
-        }
-        #expect(!agentUpdate.grants.isEmpty)
-        #expect(mutableData == nil)
-    }
+		guard case .agentUpdateV2(let agentUpdate, let mutableData) = validated else {
+			Issue.record("expected .agentUpdateV2")
+			return
+		}
+		#expect(!agentUpdate.grants.isEmpty)
+		#expect(mutableData == nil)
+	}
 
-    @Test func testAgentUpdateV2ProposalAnchorValidateRejectsWrongKey() throws {
-        let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
-        let invitationAgent = acceptorAnchor.createHelloAgent()
-        let wrongAgent = AgentPrivateKey()
-        let knownAnchor = PublicAnchorAgent(
-            anchor: acceptorAnchor.publicAnchor,
-            // validate against a key the proposal was NOT signed by
-            agentKey: wrongAgent.publicKey
-        )
-        let mlsUpdateDigest = try TypedDigest.mock()
-        let mockContext = try TypedDigest.mock()
+	@Test func testAgentUpdateV2ProposalAnchorValidateRejectsWrongKey() throws {
+		let acceptorAnchor = PrivateActiveAnchor.create(for: Atproto.DID.mock())
+		let invitationAgent = acceptorAnchor.createHelloAgent()
+		let wrongAgent = AgentPrivateKey()
+		let knownAnchor = PublicAnchorAgent(
+			anchor: acceptorAnchor.publicAnchor,
+			// validate against a key the proposal was NOT signed by
+			agentKey: wrongAgent.publicKey
+		)
+		let mlsUpdateDigest = try TypedDigest.mock()
+		let mockContext = try TypedDigest.mock()
 
-        let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
-            leafNodeUpdate: mlsUpdateDigest.wireFormat,
-            agentUpdate: .mock(),
-            signedIdentityMutable: nil,
-            context: mockContext
-        )
-        let wireProposal = try proposal.wireFormat
+		let proposal = try invitationAgent.privateKey.proposeAgentUpdateV2(
+			leafNodeUpdate: mlsUpdateDigest.wireFormat,
+			agentUpdate: .mock(),
+			signedIdentityMutable: nil,
+			context: mockContext
+		)
+		let wireProposal = try proposal.wireFormat
 
-        #expect(throws: ProtocolError.authenticationError) {
-            let _ = try CommProposal.finalParse(wireProposal)
-                .validate(
-                    knownAnchor: knownAnchor,
-                    context: mockContext,
-                    mlsUpdateDigest: mlsUpdateDigest
-                )
-        }
-    }
+		#expect(throws: ProtocolError.authenticationError) {
+			let _ = try CommProposal.finalParse(wireProposal)
+				.validate(
+					knownAnchor: knownAnchor,
+					context: mockContext,
+					mlsUpdateDigest: mlsUpdateDigest
+				)
+		}
+	}
 
-    // MARK: - mailboxGrantVersion gate
+	// MARK: - mailboxGrantVersion gate
 
-    @Test func testSupportsMailboxGrantsBoundary() {
-        // Just below the threshold — deliberately still above
-        // pqDomainSeparationVersion (3.0.0), the case the original 2.4.0
-        // threshold got wrong: a version already stamped by every PQ
-        // connection must NOT pass this gate.
-        let below = AgentUpdate(
-            version: SemanticVersion(major: 3, minor: 0, patch: 9999),
-            isAppClip: false,
-            addresses: []
-        )
-        let at = AgentUpdate(
-            version: AgentUpdate.mailboxGrantVersion,
-            isAppClip: false,
-            addresses: []
-        )
-        let above = AgentUpdate(
-            version: SemanticVersion(major: 3, minor: 1, patch: 1),
-            isAppClip: false,
-            addresses: []
-        )
-        #expect(!below.supportsMailboxGrants)
-        #expect(at.supportsMailboxGrants)
-        #expect(above.supportsMailboxGrants)
-    }
+	@Test func testSupportsMailboxGrantsBoundary() {
+		// Just below the threshold — deliberately still above
+		// pqDomainSeparationVersion (3.0.0), the case the original 2.4.0
+		// threshold got wrong: a version already stamped by every PQ
+		// connection must NOT pass this gate.
+		let below = AgentUpdate(
+			version: SemanticVersion(major: 3, minor: 0, patch: 9999),
+			isAppClip: false,
+			addresses: []
+		)
+		let at = AgentUpdate(
+			version: AgentUpdate.mailboxGrantVersion,
+			isAppClip: false,
+			addresses: []
+		)
+		let above = AgentUpdate(
+			version: SemanticVersion(major: 3, minor: 1, patch: 1),
+			isAppClip: false,
+			addresses: []
+		)
+		#expect(!below.supportsMailboxGrants)
+		#expect(at.supportsMailboxGrants)
+		#expect(above.supportsMailboxGrants)
+	}
 
-    /// The soundness property `mailboxGrantVersion`'s doc comment states:
-    /// a capability tier only proves "the peer's CommProtocol has the parser"
-    /// if it exceeds every version any shipped build has ever stamped. This
-    /// is the corrected replacement for a test that once asserted the
-    /// original (unsound) 2.4.0 sat *between* pqCapableVersion and
-    /// pqDomainSeparationVersion — which put it below a version PQ
-    /// connections already stamp.
-    @Test func testMailboxGrantVersionExceedsAllStampedTiers() {
-        #expect(AgentUpdate.pqCapableVersion < AgentUpdate.mailboxGrantVersion)
-        #expect(AgentUpdate.pqDomainSeparationVersion < AgentUpdate.mailboxGrantVersion)
-    }
+	/// The soundness property `mailboxGrantVersion`'s doc comment states:
+	/// a capability tier only proves "the peer's CommProtocol has the parser"
+	/// if it exceeds every version any shipped build has ever stamped. This
+	/// is the corrected replacement for a test that once asserted the
+	/// original (unsound) 2.4.0 sat *between* pqCapableVersion and
+	/// pqDomainSeparationVersion — which put it below a version PQ
+	/// connections already stamp.
+	@Test func testMailboxGrantVersionExceedsAllStampedTiers() {
+		#expect(AgentUpdate.pqCapableVersion < AgentUpdate.mailboxGrantVersion)
+		#expect(AgentUpdate.pqDomainSeparationVersion < AgentUpdate.mailboxGrantVersion)
+	}
 }

--- a/Tests/CommProtocolTests/MLSIntroductionTests.swift
+++ b/Tests/CommProtocolTests/MLSIntroductionTests.swift
@@ -3,7 +3,7 @@
 //  CommProtocol
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/MailboxGrantTests.swift
+++ b/Tests/CommProtocolTests/MailboxGrantTests.swift
@@ -3,178 +3,190 @@
 //  CommProtocol
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 
 @testable import CommProtocol
 
 private func rangeBytes(_ range: Range<UInt8>) -> Data {
-    Data(range)
+	Data(range)
 }
 
 struct MailboxGrantTests {
 
-    private static let zeroKey = try! TypedKeyMaterial(
-        algorithm: .hmacSha256,
-        symmetricKey: SymmetricKey(data: Data(count: 32))
-    )
+	private static let zeroKey = try! TypedKeyMaterial(
+		algorithm: .hmacSha256,
+		symmetricKey: SymmetricKey(data: Data(count: 32))
+	)
 
-    // MARK: - KATs, cross-validated against germ-service's test/mailbox-hmac.spec.ts
+	// MARK: - KATs, cross-validated against germ-service's test/mailbox-hmac.spec.ts
 
-    @Test func testAddressKnownAnswer() throws {
-        let grant = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
-        // Independently computed: hmac.new(bytes(32), b"germ-addr:v1" + b"ger.mx",
-        // sha256).hexdigest() == 193221da6fb96fb001ff056007a9e84792acd4b34ab8af79905e7d86d8976435
-        // — the exact vector in germ-service's test/mailbox-hmac.spec.ts. This
-        // asserts the base64url string form, since that's what actually rides
-        // the wire (and what `putTag` below is keyed against).
-        #expect(grant.address == "GTIh2m-5b7AB_wVgB6noR5Ks1LNKuK95kF59htiXZDU")
-    }
+	@Test func testAddressKnownAnswer() throws {
+		let grant = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
+		// Independently computed: hmac.new(bytes(32), b"germ-addr:v1" + b"ger.mx",
+		// sha256).hexdigest() == 193221da6fb96fb001ff056007a9e84792acd4b34ab8af79905e7d86d8976435
+		// — the exact vector in germ-service's test/mailbox-hmac.spec.ts. This
+		// asserts the base64url string form, since that's what actually rides
+		// the wire (and what `putTag` below is keyed against).
+		#expect(grant.address == "GTIh2m-5b7AB_wVgB6noR5Ks1LNKuK95kF59htiXZDU")
+	}
 
-    @Test func testPutTagKnownAnswer() throws {
-        let grant = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
-        let nonce = rangeBytes(0..<32)
-        let bodyDigest = rangeBytes(32..<64)
-        let tag = grant.putTag(nonce: nonce, bodyDigest: bodyDigest)
-        // germ-service's own putTag KAT exercises the raw HMAC in isolation
-        // against a placeholder address string ("some-address-string"), which
-        // this API can't reproduce directly — a grant always signs under its
-        // own derived address. So this vector instead chains off the address
-        // KAT above (independently computed the same way: hmac.new(bytes(32),
-        // b"germ-put:v1" + address.encode() + nonce + bodyDigest,
-        // sha256).hexdigest()), exercising the real coupled API rather than
-        // the server's decoupled one.
-        #expect(
-            tag
-                == Data(
-                    hexString: "67ec98aad3d2bf4551195c3a23db92c4a2f79cda35732c3eca9ac67eda19b1b6"
-                )
-        )
-    }
+	@Test func testPutTagKnownAnswer() throws {
+		let grant = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
+		let nonce = rangeBytes(0..<32)
+		let bodyDigest = rangeBytes(32..<64)
+		let tag = grant.putTag(nonce: nonce, bodyDigest: bodyDigest)
+		// germ-service's own putTag KAT exercises the raw HMAC in isolation
+		// against a placeholder address string ("some-address-string"), which
+		// this API can't reproduce directly — a grant always signs under its
+		// own derived address. So this vector instead chains off the address
+		// KAT above (independently computed the same way: hmac.new(bytes(32),
+		// b"germ-put:v1" + address.encode() + nonce + bodyDigest,
+		// sha256).hexdigest()), exercising the real coupled API rather than
+		// the server's decoupled one.
+		#expect(
+			tag
+				== Data(
+					hexString:
+						"67ec98aad3d2bf4551195c3a23db92c4a2f79cda35732c3eca9ac67eda19b1b6"
+				)
+		)
+	}
 
-    @Test func testAddressDiffersByServiceHost() throws {
-        let a = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
-        let b = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "other.example", expiration: .now)
-        #expect(a.address != b.address)
-    }
+	@Test func testAddressDiffersByServiceHost() throws {
+		let a = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
+		let b = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "other.example", expiration: .now)
+		#expect(a.address != b.address)
+	}
 
-    @Test func testPutTagDiffersByNonce() throws {
-        let grant = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
-        let digest = rangeBytes(32..<64)
-        let a = grant.putTag(nonce: rangeBytes(0..<32), bodyDigest: digest)
-        let b = grant.putTag(nonce: rangeBytes(1..<33), bodyDigest: digest)
-        #expect(a != b)
-    }
+	@Test func testPutTagDiffersByNonce() throws {
+		let grant = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
+		let digest = rangeBytes(32..<64)
+		let a = grant.putTag(nonce: rangeBytes(0..<32), bodyDigest: digest)
+		let b = grant.putTag(nonce: rangeBytes(1..<33), bodyDigest: digest)
+		#expect(a != b)
+	}
 
-    @Test func testRejectsAKeyThatIsNot32Bytes() {
-        #expect(throws: (any Error).self) {
-            try TypedKeyMaterial(algorithm: .hmacSha256, symmetricKey: SymmetricKey(data: Data(count: 16)))
-        }
-    }
+	@Test func testRejectsAKeyThatIsNot32Bytes() {
+		#expect(throws: (any Error).self) {
+			try TypedKeyMaterial(
+				algorithm: .hmacSha256,
+				symmetricKey: SymmetricKey(data: Data(count: 16)))
+		}
+	}
 
-    @Test func testRejectsAnAuthKeyOfTheWrongAlgorithm() {
-        let wrongAlgorithm = try! TypedKeyMaterial(
-            algorithm: .chaCha20Poly1305,
-            symmetricKey: SymmetricKey(size: .bits256)
-        )
-        #expect(throws: (any Error).self) {
-            try MailboxGrant(authKey: wrongAlgorithm, serviceHost: "ger.mx", expiration: .now)
-        }
-    }
+	@Test func testRejectsAnAuthKeyOfTheWrongAlgorithm() {
+		let wrongAlgorithm = try! TypedKeyMaterial(
+			algorithm: .chaCha20Poly1305,
+			symmetricKey: SymmetricKey(size: .bits256)
+		)
+		#expect(throws: (any Error).self) {
+			try MailboxGrant(
+				authKey: wrongAlgorithm, serviceHost: "ger.mx", expiration: .now)
+		}
+	}
 
-    // MARK: - Equatable (excludes expiration)
+	// MARK: - Equatable (excludes expiration)
 
-    @Test func testEqualityIgnoresExpiration() throws {
-        let a = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: Date())
-        let b = try MailboxGrant(
-            authKey: Self.zeroKey,
-            serviceHost: "ger.mx",
-            expiration: Date().addingTimeInterval(3600)
-        )
-        #expect(a == b)
-    }
+	@Test func testEqualityIgnoresExpiration() throws {
+		let a = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: Date())
+		let b = try MailboxGrant(
+			authKey: Self.zeroKey,
+			serviceHost: "ger.mx",
+			expiration: Date().addingTimeInterval(3600)
+		)
+		#expect(a == b)
+	}
 
-    @Test func testInequalityByAuthKey() throws {
-        let otherKey = try TypedKeyMaterial(
-            algorithm: .hmacSha256,
-            symmetricKey: SymmetricKey(data: Data(repeating: 1, count: 32))
-        )
-        let a = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
-        let b = try MailboxGrant(authKey: otherKey, serviceHost: "ger.mx", expiration: .now)
-        #expect(a != b)
-    }
+	@Test func testInequalityByAuthKey() throws {
+		let otherKey = try TypedKeyMaterial(
+			algorithm: .hmacSha256,
+			symmetricKey: SymmetricKey(data: Data(repeating: 1, count: 32))
+		)
+		let a = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: .now)
+		let b = try MailboxGrant(authKey: otherKey, serviceHost: "ger.mx", expiration: .now)
+		#expect(a != b)
+	}
 
-    // MARK: - CBOR round-trip
+	// MARK: - CBOR round-trip
 
-    @Test func testCborRoundTrip() throws {
-        let original = try MailboxGrant(
-            authKey: Self.zeroKey,
-            serviceHost: "ger.mx",
-            expiration: Date()
-        )
-        let encoded = try original.wireFormat
-        let decoded = try MailboxGrant(wireFormat: encoded)
-        #expect(decoded == original)
-        #expect(decoded.expiration == original.expiration)  // Equatable ignores this — check directly
-    }
+	@Test func testCborRoundTrip() throws {
+		let original = try MailboxGrant(
+			authKey: Self.zeroKey,
+			serviceHost: "ger.mx",
+			expiration: Date()
+		)
+		let encoded = try original.wireFormat
+		let decoded = try MailboxGrant(wireFormat: encoded)
+		#expect(decoded == original)
+		#expect(decoded.expiration == original.expiration)  // Equatable ignores this — check directly
+	}
 
-    // MARK: - Wire-pinning
+	// MARK: - Wire-pinning
 
-    @Test func testCborWireFormatGolden() throws {
-        let key = try TypedKeyMaterial(
-            algorithm: .hmacSha256,
-            symmetricKey: SymmetricKey(data: Data(count: 32))
-        )
-        let grant = try MailboxGrant(
-            authKey: key,
-            serviceHost: "ger.mx",
-            expiration: RoundedDate(hoursSinceEpoch: 471442)
-        )
-        let encoded = try grant.wireFormat
-        // Locks the encoding against drift: a renamed CodingKeys raw value or
-        // a reordered field must fail HERE, in CI. Byte-verified by hand at
-        // introduction: a3 (map, 3 pairs) / 61 65 (key "e") 1a 00073192
-        // (uint32 471442) / 61 68 (key "h") 66 <"ger.mx"> (text, 6 bytes) /
-        // 61 6b (key "k") 58 21 <05 + 32 zero bytes> (byte string, 33 bytes:
-        // the .hmacSha256 algorithm tag + a 32-byte all-zero key) — RFC 8949
-        // bytewise key order ("e" < "h" < "k").
-        #expect(
-            encoded
-                == Data(
-                    hexString:
-                        "a361651a000731926168666765722e6d78616b5821050000000000000000000000000000000000000000000000000000000000000000"
-                )
-        )
-    }
+	@Test func testCborWireFormatGolden() throws {
+		let key = try TypedKeyMaterial(
+			algorithm: .hmacSha256,
+			symmetricKey: SymmetricKey(data: Data(count: 32))
+		)
+		let grant = try MailboxGrant(
+			authKey: key,
+			serviceHost: "ger.mx",
+			expiration: RoundedDate(hoursSinceEpoch: 471442)
+		)
+		let encoded = try grant.wireFormat
+		// Locks the encoding against drift: a renamed CodingKeys raw value or
+		// a reordered field must fail HERE, in CI. Byte-verified by hand at
+		// introduction: a3 (map, 3 pairs) / 61 65 (key "e") 1a 00073192
+		// (uint32 471442) / 61 68 (key "h") 66 <"ger.mx"> (text, 6 bytes) /
+		// 61 6b (key "k") 58 21 <05 + 32 zero bytes> (byte string, 33 bytes:
+		// the .hmacSha256 algorithm tag + a 32-byte all-zero key) — RFC 8949
+		// bytewise key order ("e" < "h" < "k").
+		#expect(
+			encoded
+				== Data(
+					hexString:
+						"a361651a000731926168666765722e6d78616b5821050000000000000000000000000000000000000000000000000000000000000000"
+				)
+		)
+	}
 
-    // MARK: - ProtocolAddress bridge
+	// MARK: - ProtocolAddress bridge
 
-    @Test func testProtocolAddressBridgeRoundTrip() throws {
-        let grant = try MailboxGrant(authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: Date())
-        let address = ProtocolAddress(mailboxGrant: grant)
-        #expect(address.serviceHost == grant.serviceHost)
-        #expect(address.mailboxGrant == grant)
-        #expect(address.mailboxGrant?.expiration == grant.expiration)
-    }
+	@Test func testProtocolAddressBridgeRoundTrip() throws {
+		let grant = try MailboxGrant(
+			authKey: Self.zeroKey, serviceHost: "ger.mx", expiration: Date())
+		let address = ProtocolAddress(mailboxGrant: grant)
+		#expect(address.serviceHost == grant.serviceHost)
+		#expect(address.mailboxGrant == grant)
+		#expect(address.mailboxGrant?.expiration == grant.expiration)
+	}
 
-    @Test func testProtocolAddressBridgeDiscriminatesLegacyUUID() {
-        // Legacy addresses are `crypto.randomUUID()` — 36 characters, which
-        // decode as base64url to 27 bytes, never 32. Never a grant.
-        let legacy = ProtocolAddress(
-            identifier: UUID().uuidString,
-            serviceHost: "ger.mx",
-            expiration: Date()
-        )
-        #expect(legacy.mailboxGrant == nil)
-    }
+	@Test func testProtocolAddressBridgeDiscriminatesLegacyUUID() {
+		// Legacy addresses are `crypto.randomUUID()` — 36 characters, which
+		// decode as base64url to 27 bytes, never 32. Never a grant.
+		let legacy = ProtocolAddress(
+			identifier: UUID().uuidString,
+			serviceHost: "ger.mx",
+			expiration: Date()
+		)
+		#expect(legacy.mailboxGrant == nil)
+	}
 
-    @Test func testProtocolAddressBridgeRejectsGarbageIdentifier() {
-        let garbage = ProtocolAddress(
-            identifier: "not-base64url-shaped-at-all!!",
-            serviceHost: "ger.mx",
-            expiration: Date()
-        )
-        #expect(garbage.mailboxGrant == nil)
-    }
+	@Test func testProtocolAddressBridgeRejectsGarbageIdentifier() {
+		let garbage = ProtocolAddress(
+			identifier: "not-base64url-shaped-at-all!!",
+			serviceHost: "ger.mx",
+			expiration: Date()
+		)
+		#expect(garbage.mailboxGrant == nil)
+	}
 }

--- a/Tests/CommProtocolTests/PQCardUpgradeTests.swift
+++ b/Tests/CommProtocolTests/PQCardUpgradeTests.swift
@@ -6,7 +6,7 @@
 //
 
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 
@@ -70,8 +70,9 @@ struct PQCardUpgradeTests {
 			context: context
 		)
 
-		guard case .pqCardUpgrade(let validated) = try validate(
-			proposal, context: context, message: message)
+		guard
+			case .pqCardUpgrade(let validated) = try validate(
+				proposal, context: context, message: message)
 		else {
 			#expect(Bool(false), "expected pqCardUpgrade")
 			return
@@ -92,8 +93,9 @@ struct PQCardUpgradeTests {
 			context: context
 		)
 
-		guard case .pqCardUpgrade(let validated) = try validate(
-			proposal, context: context, message: message)
+		guard
+			case .pqCardUpgrade(let validated) = try validate(
+				proposal, context: context, message: message)
 		else {
 			#expect(Bool(false), "expected pqCardUpgrade")
 			return
@@ -112,8 +114,9 @@ struct PQCardUpgradeTests {
 			context: context
 		)
 
-		guard case .pqCardUpgrade(let validated) = try validate(
-			proposal, context: context, message: message)
+		guard
+			case .pqCardUpgrade(let validated) = try validate(
+				proposal, context: context, message: message)
 		else {
 			#expect(Bool(false), "expected pqCardUpgrade")
 			return

--- a/Tests/CommProtocolTests/SessionEncryption/PQEstablishmentHandoffTests.swift
+++ b/Tests/CommProtocolTests/SessionEncryption/PQEstablishmentHandoffTests.swift
@@ -13,7 +13,7 @@
 import AtprotoTypes
 import AtprotoTypesMocks
 import CommProtocolMocks
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 

--- a/Tests/CommProtocolTests/TypedKeyTest.swift
+++ b/Tests/CommProtocolTests/TypedKeyTest.swift
@@ -5,7 +5,7 @@
 //  Created by Mark @ Germ on 6/21/24.
 //
 
-import CryptoKit
+import Crypto
 import Foundation
 import Testing
 


### PR DESCRIPTION
Unguarded `import CryptoKit` across 46 files was the last blocker to building
this package for Linux and Android. swift-crypto covers the entire API surface
used here — `Curve25519.Signing`/`.KeyAgreement`, `SymmetricKey`, `SHA256`,
`ChaChaPoly`, `HPKE` — and delegates to CryptoKit on Apple platforms, so
behavior is unchanged there. No `SecureEnclave`, `SecKey`, or Keychain usage
anywhere, so nothing needed redesign; the swap is mechanical.

Also raises the AtprotoTypes floor to 0.5.0, the first release that builds on
those platforms, stated in the manifest for the same reason as the swift-bases
floor: consumers ignore this package's lockfile.

All 157 tests pass on macOS. The Linux and Android CI legs that prove the other
platforms land stacked on this in #52.

Part of GER-2175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
