### PR TITLE
Name the workspace package correctly in olive-pandas-require

### DIFF
--- a/.changeset/olive-pandas-require.md
+++ b/.changeset/olive-pandas-require.md
@@ -1,5 +1,5 @@
 ---
-"@germ-network/comm-protocol": patch
+"@germ-network/autonomous-comm-protocol": patch
 ---
 
 Require swift-bases 0.3.0 in the manifest. `MailboxGrant` is written against 0.3.0's throwing `Data(base64URLEncoded:)`, but `Package.swift` still permitted 0.2.x — and consumers resolve from the manifest, not this package's `Package.resolved`, so the previous change expressed the adoption only locally.


### PR DESCRIPTION
The pending release is stuck: the `Release` run on `main` fails with

> Found changeset olive-pandas-require for package @germ-network/comm-protocol which is not in the workspace

`.changeset/olive-pandas-require.md` drops the `autonomous-` prefix; the
workspace package (package.json, and the sibling changeset) is
`@germ-network/autonomous-comm-protocol`. One-word fix; the next push to `main`
after this merges regenerates the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
