### PR TITLE
Enforce swift-format lint in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Mass-reformat with swift-format; use this file to skip it in blame.
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+7d5768a5422219b3c2314e8a7ee6eba60e98c450

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -16,6 +16,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.2
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Lint
+        run: swift format lint --recursive --configuration .swift-format --strict Sources Tests
+
   linux_test:
     name: Test Linux
     runs-on: ubuntu-latest

--- a/Sources/CommProtocol/IdentityKeys/Curve25519+SigningKey.swift
+++ b/Sources/CommProtocol/IdentityKeys/Curve25519+SigningKey.swift
@@ -17,16 +17,3 @@ extension Curve25519.Signing.PrivateKey: PrivateSigningKey {
 extension Curve25519.Signing.PublicKey: PublicSigningKey {
 	public static let signingAlgorithm: SigningKeyAlgorithm = .curve25519
 }
-
-extension Curve25519.Signing.PublicKey: @retroactive Equatable {
-	public static func == (lhs: Curve25519.Signing.PublicKey, rhs: Curve25519.Signing.PublicKey)
-		-> Bool
-	{
-		return lhs.rawRepresentation == rhs.rawRepresentation
-	}
-}
-extension Curve25519.Signing.PublicKey: @retroactive Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(rawRepresentation)
-	}
-}

--- a/Sources/CommProtocol/IdentityKeys/SigningKey.swift
+++ b/Sources/CommProtocol/IdentityKeys/SigningKey.swift
@@ -30,7 +30,12 @@ protocol PrivateSigningKey: TypedKeyMaterialInput, Sendable {
 	func signature<D>(for data: D) throws -> Data where D: DataProtocol
 }
 
-public protocol PublicSigningKey: TypedKeyMaterialInput, Hashable, Sendable {
+// Deliberately not Hashable: nothing in this package or any known consumer
+// hashes/compares a PublicSigningKey directly (AgentPublicKey, IdentityPublicKey,
+// and AnchorPublicKey all derive their own Hashable/Equatable from a wireformat-
+// backed id instead), and requiring it forced a @retroactive Curve25519.Signing.PublicKey
+// conformance that swift-format's AvoidRetroactiveConformances rule flags.
+public protocol PublicSigningKey: TypedKeyMaterialInput, Sendable {
 	static var signingAlgorithm: SigningKeyAlgorithm { get }
 
 	init<D>(rawRepresentation data: D) throws where D: ContiguousBytes

--- a/Tests/CommProtocolTests/MailboxGrantTests.swift
+++ b/Tests/CommProtocolTests/MailboxGrantTests.swift
@@ -127,7 +127,8 @@ struct MailboxGrantTests {
 		let encoded = try original.wireFormat
 		let decoded = try MailboxGrant(wireFormat: encoded)
 		#expect(decoded == original)
-		#expect(decoded.expiration == original.expiration)  // Equatable ignores this — check directly
+		// Equatable ignores this — check directly
+		#expect(decoded.expiration == original.expiration)
 	}
 
 	// MARK: - Wire-pinning


### PR DESCRIPTION
Fixes the one real strict-lint failure (an over-length trailing comment) and adds a CI lint job.

Also fixes the two `AvoidRetroactiveConformances` findings that surfaced: `PublicSigningKey` required `Hashable`, forcing `@retroactive Equatable`/`Hashable` conformances on `Curve25519.Signing.PublicKey`. Checked every concrete consumer (`AgentPublicKey`, `IdentityPublicKey`, `AnchorPublicKey`) — none of them actually hash/compare a `PublicSigningKey` directly, they all derive `Hashable`/`Equatable` from a wireformat-backed `id` instead. Also grepped known downstream consumers checked out locally (CoreAppLogic's three subpackages, germ-service-client, prototype-germ-service-client) for any reference to `PublicSigningKey` — none found. Dropped the requirement rather than keep the retroactive conformances — all 157 tests pass.

Part of an org-wide sweep bringing consistent swift-format lint to Germ's standalone Swift packages.